### PR TITLE
Enable dependabot to update submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Description
This enables [dependabot](https://github.com/dependabot) for this repository, specifically to keep git submodules up-to-date. Once merged, dependabot will automatically open pull requests to update `pipeline-Nextflow-config` and `pipeline-Nextflow-module` to the latest versions. Thereafter, it will check weekly to see if new commits have been made to those submodules, opening new PRs as necessary.

Here is an example pull request from my training repository: https://github.com/uclahs-cds/training-nwiltsie/pull/14

No PRs, including this one and all dependabot PRs, will have the power to make updates without human intervention. The changes will still need to be tested manually before they should be merged.

### Errata
* Dependabot completely ignores tags and will always attempt to update to the latest commit (see https://github.com/dependabot/dependabot-core/issues/1639). That could create a lot of churn if we're regularly committing to the submodules.
  * One solution to that could be to adopt a [gitflow-like model](https://github.com/dependabot/dependabot-core/issues/1639) in those repos, where changes are initially merged into a `develop` branch and new releases are created by periodically merging `develop` into `main`.

## Testing Results

No tests run - infrastructure change only.

# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
