### PR TITLE
Use wildcards in dependabot submodule grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
       # "pipeline-submodules" is an arbitrary name
       pipeline-submodules:
         patterns:
-          - pipeline-Nextflow-config
-          - pipeline-Nextflow-module
+          - "*/pipeline-Nextflow-config"
+          - "*/pipeline-Nextflow-module"


### PR DESCRIPTION
Alas, #74 did not achieve what I wanted:

https://github.com/uclahs-cds/pipeline-recalibrate-BAM/network/updates/842195399

```
updater | 2024/06/14 22:50:16 INFO <job_842195399> Starting job processing
updater | 2024/06/14 22:50:16 WARN <job_842195399> Please check your configuration as there are groups where no dependencies match:
updater | - pipeline-submodules
updater | 
updater | This can happen if:
updater | - the group's 'pattern' rules are misspelled
updater | - your configuration's 'allow' rules do not permit any of the dependencies that match the group
updater | - the dependencies that match the group rules have been removed from your project
updater | 
updater | 2024/06/14 22:50:17 INFO <job_842195399> Starting grouped update job for uclahs-cds/pipeline-recalibrate-BAM
updater | 2024/06/14 22:50:17 INFO <job_842195399> Found 1 group(s).
updater | 2024/06/14 22:50:17 WARN <job_842195399> Skipping update group for 'pipeline-submodules' as it does not match any allowed dependencies.
```

I think the issue is that the dependencies are technically labelled as `external/pipeline-Nextflow-config` and `external/pipeline-Nextflow-module`, so my patterns did not match. Hopefully adding these wildcards (as detailed in [the docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-1)) makes it work correctly.

I don't want to hard-code `external/pipeline-Nextflow-config` because I want to duplicate these changes across all of our pipelines, and a wildcard would be more convenient for that.