### PR TITLE
Organizational and cleanup tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### [Changed]
+- Use `run_validate_PipeVal_with_metadata` to gate on validation
+- Move index/dictionary file discovery to configuration stage
+- Include all parameters from `default.config` in the README
+
 ---
 
 ## [1.0.1] - 2024-05-29

--- a/README.md
+++ b/README.md
@@ -150,11 +150,30 @@ For normal-only or tumour-only samples, exclude the fields for the other state.
 | `bundle_v0_dbsnp138_vcf_gz` | Yes | path | Absolute path to dbsnp file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz` |
 | `bundle_contest_hapmap_3p3_vcf_gz` | Yes | path | Absolute path to HapMap 3.3 biallelic sites file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz` |
 | `work_dir` | optional | path | Path of working directory for Nextflow. When included in the sample config file, Nextflow intermediate files and logs will be saved to this directory. With ucla_cds, the default is `/scratch` and should only be changed for testing/development. Changing this directory to `/hot` or `/tmp` can lead to high server latency and potential disk space limitations, respectively. |
-| `docker_container_registry` | optional | string | Registry containing tool Docker images. Default: `ghcr.io/uclahs-cds` |
-| `metapipeline_delete_input_bams` | optional | boolean | Set to true to delete the input BAM files once the initial processing step is complete. **WARNING**: This option should NOT be used for individual runs of recalibate-BAM; it's intended for metapipeline-DNA to optimize disk space usage by removing files that are no longer needed from the `workDir`. |
-| `metapipeline_final_output_dir` | optional | string | Absolute path for the final output directory of metapipeline-DNA that's expected to contain the output BAM from align-DNA. **WARNING**: This option should not be used for individual runs of recalibrate-BAM; it's intended for metapipeline-DNA to optimize disk space usage. |
-| `metapipeline_states_to_delete` | optional | list | List of states for which to delete input BAMs. **WARNING**: This option should not be used for individual runs of recalibrate-BAM; it's intended for metapipeline-DNA to optimize disk space usage. |
 | `base_resource_update` | optional | namespace | Namespace of parameters to update base resource allocations in the pipeline. Usage and structure are detailed in `template.config` and below. |
+
+
+The below parameters have default values defined in [`default.config`](./config/default.config) and generally do not need to be set by the user.
+
+| Optional Parameter | Type | Description |
+| :------------------| :----| :-----------|
+| `metapipeline_delete_input_bams` | boolean | Set to true to delete the input BAM files once the initial processing step is complete. **WARNING**: This option should NOT be used for individual runs of recalibate-BAM; it's intended for metapipeline-DNA to optimize disk space usage by removing files that are no longer needed from the `workDir`. |
+| `metapipeline_final_output_dir` | string | Absolute path for the final output directory of metapipeline-DNA that's expected to contain the output BAM from align-DNA. **WARNING**: This option should not be used for individual runs of recalibrate-BAM; it's intended for metapipeline-DNA to optimize disk space usage. |
+| `metapipeline_states_to_delete` | list | List of states for which to delete input BAMs. **WARNING**: This option should not be used for individual runs of recalibrate-BAM; it's intended for metapipeline-DNA to optimize disk space usage. |
+| `cache_intermediate_pipeline_steps` | boolean | Enable process caching from Nextflow. |
+| `ucla_cds` | boolean | Overwrite default memory and CPU values by cluster-specific configs. |
+| `docker_container_registry` | string  | Registry containing tool Docker images. |
+| `docker_image_gatk`, `gatk_version` | string  | Docker image name and version for GATK. |
+| `docker_image_pipeval`, `pipeval_version` | string | Docker image name and version for PipeVal. |
+| `docker_image_gatk3`, `gatk3_version` | string | Docker image name and version for GATK3. |
+| `docker_image_picard`, `picard_version` | string | Docker image name and version for Picard. |
+| `docker_image_samtools`, `samtools_version` | string | Docker image name and version for SAMtools. |
+| `reference_fasta_fai`, `reference_fasta_dict` | path | Index and dictionary files for the required input. Default: Matching `.fai` and `.dict` files in the same directory. |
+| `bundle_v0_dbsnp138_vcf_gz_tbi` | path | Index file for the required input. Default: Matching `.tbi` file in the same directory. |
+| `bundle_known_indels_vcf_gz_tbi` | path | Index file for the required input. Default: Matching `.tbi` file in the same directory. |
+| `bundle_contest_hapmap_3p3_vcf_gz_tbi`| path | Index file for the required input. Default: Matching `.tbi` file in the same directory. |
+| `bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi` | path | Index file for the required input. Default: Matching `.tbi` file in the same directory. |
+
 
 #### Base resource allocation updaters
 To update the base resource (cpus or memory) allocations for processes, use the following structure and add the necessary parts. The default allocations can be found in the [node-specific config files](./config/)

--- a/config/default.config
+++ b/config/default.config
@@ -1,6 +1,8 @@
 import nextflow.util.SysHelper
+import nextflow.Nextflow
 
 // Default inputs/parameters of the pipeline
+
 params {
     min_cpus = 1
     min_memory = 1.MB
@@ -30,6 +32,14 @@ params {
     docker_image_samtools = "${-> params.docker_container_registry}/samtools:${params.samtools_version}"
 
     gatk_ir_compression = 1
+
+    // These parameters are inferred from the input files. The user can override them in the config file if required.
+    reference_fasta_fai = "${-> params.reference_fasta}.fai"
+    reference_fasta_dict = "${-> Nextflow.file(params.reference_fasta).resolveSibling(Nextflow.file(params.reference_fasta).getBaseName() + '.dict')}"
+    bundle_known_indels_vcf_gz_tbi = "${-> params.bundle_known_indels_vcf_gz}.tbi"
+    bundle_contest_hapmap_3p3_vcf_gz_tbi = "${-> params.bundle_contest_hapmap_3p3_vcf_gz}.tbi"
+    bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi = "${-> params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi"
+    bundle_v0_dbsnp138_vcf_gz_tbi = "${-> params.bundle_v0_dbsnp138_vcf_gz}.tbi"
 }
 
 // Process specific scope

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -56,26 +56,56 @@ reference_fasta:
   mode: 'r'
   required: true
   help: 'Absolute path to reference genome fasta'
+reference_fasta_fai:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'Absolute path to reference genome fasta index file'
+reference_fasta_dict:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'Absolute path to reference genome fasta dictionary'
 bundle_mills_and_1000g_gold_standard_indels_vcf_gz:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Absolute path to Mills and 1000g gold standard INDELs VCF'
+bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'Absolute path to Mills and 1000g gold standard INDELs VCF index file'
 bundle_known_indels_vcf_gz:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Absolute path to known INDELs VCF'
+bundle_known_indels_vcf_gz_tbi:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'Absolute path to known INDELs VCF index file'
 bundle_v0_dbsnp138_vcf_gz:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Absolute path to v0 dbSNP 138 VCF'
+bundle_v0_dbsnp138_vcf_gz_tbi:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'Absolute path to v0 dbSNP 138 VCF index file'
 bundle_contest_hapmap_3p3_vcf_gz:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Absolute path to ConEst HapMap 3p3 VCF'
+bundle_contest_hapmap_3p3_vcf_gz_tbi:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'Absolute path to ConEst HapMap 3p3 VCF index file'
 metapipeline_delete_input_bams:
   type: 'Bool'
   required: true

--- a/main.nf
+++ b/main.nf
@@ -120,13 +120,13 @@ workflow {
     /**
     *   Interval extraction and splitting
     */
-    extract_GenomeIntervals("${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict")
+    extract_GenomeIntervals(params.reference_fasta_dict)
 
     run_SplitIntervals_GATK(
         extract_GenomeIntervals.out.genomic_intervals,
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict"
+        params.reference_fasta_fai,
+        params.reference_fasta_dict
     )
 
     run_SplitIntervals_GATK.out.interval_list
@@ -206,10 +206,10 @@ workflow {
 
     run_GetPileupSummaries_GATK(
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
+        params.reference_fasta_fai,
+        params.reference_fasta_dict,
         params.bundle_contest_hapmap_3p3_vcf_gz,
-        "${params.bundle_contest_hapmap_3p3_vcf_gz}.tbi",
+        params.bundle_contest_hapmap_3p3_vcf_gz_tbi,
         input_ch_summary_intervals,
         input_ch_merged_bams
     )
@@ -254,8 +254,8 @@ workflow {
 
     run_DepthOfCoverage_GATK(
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
+        params.reference_fasta_fai,
+        params.reference_fasta_dict,
         input_ch_summary_intervals,
         input_ch_merged_bams
     )

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -182,14 +182,14 @@ workflow recalibrate_base {
 
     run_BaseRecalibrator_GATK(
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
+        params.reference_fasta_fai,
+        params.reference_fasta_dict,
         params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
-        "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
+        params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi,
         params.bundle_known_indels_vcf_gz,
-        "${params.bundle_known_indels_vcf_gz}.tbi",
+        params.bundle_known_indels_vcf_gz_tbi,
         params.bundle_v0_dbsnp138_vcf_gz,
-        "${params.bundle_v0_dbsnp138_vcf_gz}.tbi",
+        params.bundle_v0_dbsnp138_vcf_gz_tbi,
         base_recalibrator_intervals,
         params.input.recalibration_table,
         input_ch_base_recalibrator
@@ -220,8 +220,8 @@ workflow recalibrate_base {
 
     run_ApplyBQSR_GATK(
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
+        params.reference_fasta_fai,
+        params.reference_fasta_dict,
         input_ch_apply_bqsr
     )
 

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -15,8 +15,8 @@ include {
         reference_fasta: path to reference genome fasta file
         reference_fasta_fai: path to index for reference fasta
         reference_fasta_dict: path to dictionary for reference fasta
-        bundle_mills_and_1000g_gold_standards_vcf_gz: path to standard Mills and 1000 genomes variants
-        bundle_mills_and_1000g_gold_standards_vcf_gz_tbi: path to index file for Mills and 1000g variants
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz: path to standard Mills and 1000 genomes variants
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi: path to index file for Mills and 1000g variants
         bundle_known_indels_vcf_gz: path to set of known indels
         bundle_known_indels_vcf_gz_tbi: path to index of known indels VCF
         bundle_v0_dbsnp138_vcf_gz: path to dbSNP variants
@@ -46,8 +46,8 @@ process run_BaseRecalibrator_GATK {
     path(reference_fasta)
     path(reference_fasta_fai)
     path(reference_fasta_dict)
-    path(bundle_mills_and_1000g_gold_standards_vcf_gz)
-    path(bundle_mills_and_1000g_gold_standards_vcf_gz_tbi)
+    path(bundle_mills_and_1000g_gold_standard_indels_vcf_gz)
+    path(bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi)
     path(bundle_known_indels_vcf_gz)
     path(bundle_known_indels_vcf_gz_tbi)
     path(bundle_v0_dbsnp138_vcf_gz)
@@ -71,7 +71,7 @@ process run_BaseRecalibrator_GATK {
             ${all_ir_bams} \
             --reference ${reference_fasta} \
             --verbosity INFO \
-            --known-sites ${bundle_mills_and_1000g_gold_standards_vcf_gz} \
+            --known-sites ${bundle_mills_and_1000g_gold_standard_indels_vcf_gz} \
             --known-sites ${bundle_known_indels_vcf_gz} \
             --known-sites ${bundle_v0_dbsnp138_vcf_gz} \
             --output ${sample_id}_recalibration_table.grp \

--- a/module/indel-realignment.nf
+++ b/module/indel-realignment.nf
@@ -161,24 +161,24 @@ workflow realign_indels {
 
     run_RealignerTargetCreator_GATK(
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
+        params.reference_fasta_fai,
+        params.reference_fasta_dict,
         params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
-        "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
+        params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi,
         params.bundle_known_indels_vcf_gz,
-        "${params.bundle_known_indels_vcf_gz}.tbi",
+        params.bundle_known_indels_vcf_gz_tbi,
         "${params.getOrDefault('intervals', null) ?: params.work_dir + '/NO_FILE.bed'}",
         input_ch_rtc
         )
 
     run_IndelRealigner_GATK(
         params.reference_fasta,
-        "${params.reference_fasta}.fai",
-        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
+        params.reference_fasta_fai,
+        params.reference_fasta_dict,
         params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
-        "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
+        params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi,
         params.bundle_known_indels_vcf_gz,
-        "${params.bundle_known_indels_vcf_gz}.tbi",
+        params.bundle_known_indels_vcf_gz_tbi,
         run_RealignerTargetCreator_GATK.out.ir_targets
         )
 

--- a/module/indel-realignment.nf
+++ b/module/indel-realignment.nf
@@ -6,8 +6,8 @@ include { generate_standard_filename } from '../external/pipeline-Nextflow-modul
         reference_fasta: path to reference genome fasta file
         reference_fasta_fai: path to index for reference fasta
         reference_fasta_dict: path to dictionary for reference fasta
-        bundle_mills_and_1000g_gold_standards_vcf_gz: path to standard Mills and 1000 genomes variants
-        bundle_mills_and_1000g_gold_standards_vcf_gz_tbi: path to index file for Mills and 1000g variants
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz: path to standard Mills and 1000 genomes variants
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi: path to index file for Mills and 1000g variants
         bundle_known_indels_vcf_gz: path to set of known indels
         bundle_known_indels_vcf_gz_tbi: path to index of known indels VCF
         (bam, bam_index, interval_id, interval):  
@@ -34,8 +34,8 @@ process run_RealignerTargetCreator_GATK {
     path(reference_fasta)
     path(reference_fasta_fai)
     path(reference_fasta_dict)
-    path(bundle_mills_and_1000g_gold_standards_vcf_gz)
-    path(bundle_mills_and_1000g_gold_standards_vcf_gz_tbi)
+    path(bundle_mills_and_1000g_gold_standard_indels_vcf_gz)
+    path(bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi)
     path(bundle_known_indels_vcf_gz)
     path(bundle_known_indels_vcf_gz_tbi)
     path(original_intervals)
@@ -56,7 +56,7 @@ process run_RealignerTargetCreator_GATK {
         --analysis_type RealignerTargetCreator \
         ${arg_bam} \
         --reference_sequence ${reference_fasta} \
-        --known ${bundle_mills_and_1000g_gold_standards_vcf_gz} \
+        --known ${bundle_mills_and_1000g_gold_standard_indels_vcf_gz} \
         --known ${bundle_known_indels_vcf_gz} \
         --intervals ${interval} \
         --out ${output_rtc_intervals} \
@@ -74,8 +74,8 @@ process run_RealignerTargetCreator_GATK {
         reference_fasta: path to reference genome fasta file
         reference_fasta_fai: path to index for reference fasta
         reference_fasta_dict: path to dictionary for reference fasta
-        bundle_mills_and_1000g_gold_standards_vcf_gz: path to standard Mills and 1000 genomes variants
-        bundle_mills_and_1000g_gold_standards_vcf_gz_tbi: path to index file for Mills and 1000g variants
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz: path to standard Mills and 1000 genomes variants
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi: path to index file for Mills and 1000g variants
         bundle_known_indels_vcf_gz: path to set of known indels
         bundle_known_indels_vcf_gz_tbi: path to index of known indels VCF
         (bam, bam_index, interval_id, interval, RTC_interval): 
@@ -103,8 +103,8 @@ process run_IndelRealigner_GATK {
     path(reference_fasta)
     path(reference_fasta_fai)
     path(reference_fasta_dict)
-    path(bundle_mills_and_1000g_gold_standards_vcf_gz)
-    path(bundle_mills_and_1000g_gold_standards_vcf_gz_tbi)
+    path(bundle_mills_and_1000g_gold_standard_indels_vcf_gz)
+    path(bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi)
     path(bundle_known_indels_vcf_gz)
     path(bundle_known_indels_vcf_gz_tbi)
     tuple path(bam), path(bam_index), val(interval_id), path(scatter_intervals), path(target_intervals_RTC)
@@ -134,7 +134,7 @@ process run_IndelRealigner_GATK {
         ${arg_bam} \
         --reference_sequence ${reference_fasta} \
         --bam_compression ${params.gatk_ir_compression} \
-        --knownAlleles ${bundle_mills_and_1000g_gold_standards_vcf_gz} \
+        --knownAlleles ${bundle_mills_and_1000g_gold_standard_indels_vcf_gz} \
         --knownAlleles ${bundle_known_indels_vcf_gz} \
         --allow_potentially_misencoded_quality_scores \
         --targetIntervals ${target_intervals_RTC} \

--- a/module/split-intervals.nf
+++ b/module/split-intervals.nf
@@ -3,9 +3,9 @@
 
     input:
         intervals: path to set of target intervals to split
-        reference: path to reference genome fasta file
-        reference_index: path to index for reference fasta
-        reference_dict: path to dictionary for reference fasta
+        reference_fasta: path to reference genome fasta file
+        reference_fasta_index: path to index for reference fasta
+        reference_fasta_dict: path to dictionary for reference fasta
 
     params:
         params.output_dir_base: string(path)
@@ -23,9 +23,9 @@ process run_SplitIntervals_GATK {
 
     input:
     path intervals
-    path reference
-    path reference_index
-    path reference_dict
+    path reference_fasta
+    path reference_fasta_index
+    path reference_fasta_dict
 
     output:
     path "*-contig.interval_list", emit: interval_list
@@ -39,7 +39,7 @@ process run_SplitIntervals_GATK {
         for i in `grep -E '^(chr|)([0-9]+|X|Y|M)\$' ${intervals}`
         do
             gatk SplitIntervals \
-                -R ${reference} \
+                -R ${reference_fasta} \
                 -L ${intervals} \
                 -L \$i \
                 --interval-set-rule INTERSECTION \
@@ -51,7 +51,7 @@ process run_SplitIntervals_GATK {
         done
 
         gatk SplitIntervals \
-            -R ${reference} \
+            -R ${reference_fasta} \
             -L ${intervals} \
             \$assembled_chr_to_exclude \
             --interval-set-rule INTERSECTION \
@@ -61,7 +61,7 @@ process run_SplitIntervals_GATK {
         mv 0000-scattered.interval_list nonassembled-contig.interval_list
     else
         gatk SplitIntervals \
-            -R ${reference} \
+            -R ${reference_fasta} \
             -L ${intervals} \
             --scatter-count ${params.scatter_count} \
             ${params.split_intervals_extra_args} \

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -53,9 +53,13 @@
       "aligner": "BWA-MEM2-2.2.1",
       "blcds_registered_dataset": false,
       "bundle_contest_hapmap_3p3_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz",
+      "bundle_contest_hapmap_3p3_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz.tbi",
       "bundle_known_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz",
+      "bundle_known_indels_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi",
       "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+      "bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
       "bundle_v0_dbsnp138_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+      "bundle_v0_dbsnp138_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
       "cache_intermediate_pipeline_steps": false,
       "dataset_id": "A-mini",
       "docker_container_registry": "ghcr.io/uclahs-cds",
@@ -225,6 +229,8 @@
         }
       },
       "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "reference_fasta_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+      "reference_fasta_fai": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
       "samples_to_process": [
         {
           "id": "4915723",

--- a/test/configtest-F32.json
+++ b/test/configtest-F32.json
@@ -53,9 +53,13 @@
       "aligner": "BWA-MEM2-2.2.1",
       "blcds_registered_dataset": false,
       "bundle_contest_hapmap_3p3_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz",
+      "bundle_contest_hapmap_3p3_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz.tbi",
       "bundle_known_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz",
+      "bundle_known_indels_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi",
       "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+      "bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
       "bundle_v0_dbsnp138_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+      "bundle_v0_dbsnp138_vcf_gz_tbi": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
       "cache_intermediate_pipeline_steps": false,
       "dataset_id": "A-mini",
       "docker_container_registry": "ghcr.io/uclahs-cds",
@@ -225,6 +229,8 @@
         }
       },
       "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "reference_fasta_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+      "reference_fasta_fai": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
       "samples_to_process": [
         {
           "id": "4915723",


### PR DESCRIPTION
# Description

This PR performs a handful of re-organizational and cleanup tasks for the pipeline.

### Sidecar file searching during config

I've added the following "new" required parameters to `default.config` and `schema.yaml`. They all have default values defined by other parameters, e.g. `reference_fasta_fai = "${-> params.reference_fasta}.fai"`.

* `reference_fasta_fai`
* `reference_fasta_dict`
* `bundle_known_indels_vcf_gz_tbi`
* `bundle_contest_hapmap_3p3_vcf_gz_tbi`
* `bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi`
* `bundle_v0_dbsnp138_vcf_gz_tbi`

I say "new" parameters because the values are already in use across the pipeline - this change is to eagerly perform the discovery and validation of those files during the configuration phase. That's more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and ensures that missing files cause fast failures.

### Optional parameters listed in README

I've updated the README to include all of the parameters from `default.config` in a second table.

### PipeVal in the critical path

I've tweaked the early workflow processes to take the PipeVal validated output files rather than the raw BAM/BAI files (required https://github.com/uclahs-cds/pipeline-Nextflow-module/pull/44). That trades a little efficiency for simplicity - the downstream processing can't begin in parallel with validation, but in exchange we don't need to worry about cancelling processes or clawing back invalid outputs due to a late validation result.

### Input name harmonization

Many processes have proxy inputs for parameters - that is, those processes are always called with the same parameter as the same positional input. In those cases I renamed the input to match the parameter - for example, `run_SplitIntervals_GATK`'s `reference`, `reference_index`, and `reference_dict` inputs are now `reference_fasta`, `reference_fasta_index`, and `reference_fasta_dict`.

Harmonizing the input name with the parameter name makes it easier to trace the logic and search the codebase.

## Testing Results

- NFTest
  - log:      `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/nwiltsie-refactor/log-nftest-20240627T155900Z.log`
  - cases:    default set


# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
