### PR TITLE
Update CODEOWNERS to use team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner(s)
-*	@tyamaguchi-ucla @yashpatel6 @Faizal-Eeman
+*	@uclahs-cds/nextflow-wg


### PR DESCRIPTION
This just updates the CODEOWNERS file away from explicitly referring to @tyamaguchi-ucla, @yashpatel6, and @Faizal-Eeman to instead refer to our standard working group team.