### PR TITLE
Add tool choice AND Paralllelize BaseRecalibrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- Add tool choice for processing steps with `run_indel_realignment` and `run_base_recalibration` parameters
+- Added F8 option to resource configurations
+
 ### Changed
 
 - Update to branch of `pipeline-Nextflow-config`

--- a/README.md
+++ b/README.md
@@ -135,49 +135,6 @@ input:
 
 For normal-only or tumour-only samples, exclude the fields for the other state.
 
-#### Processing Mode Examples
-
-Run indel realignment only:
-```
----
-patient_id: "patient_id"
-run_indel_realignment: true
-run_base_recalibration: false
-input:
-  BAM:
-    normal:
-      - "/absolute/path/to/BAM"
-    tumor:
-      - "/absolute/path/to/BAM"
-```
-
-Run base recalibration only:
-```
----
-patient_id: "patient_id"
-run_indel_realignment: false
-run_base_recalibration: true
-input:
-  BAM:
-    normal:
-      - "/absolute/path/to/BAM"
-    tumor:
-      - "/absolute/path/to/BAM"
-```
-
-Run both processes (default behavior - parameters can be omitted):
-```
----
-patient_id: "patient_id"
-run_indel_realignment: true
-run_base_recalibration: true
-input:
-  BAM:
-    normal:
-      - "/absolute/path/to/BAM"
-    tumor:
-      - "/absolute/path/to/BAM"
-```
 
 ### Config
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 
 This pipeline takes BAMs and corresponding indices from [pipeline-align-DNA](https://github.com/uclahs-cds/pipeline-align-DNA) and performs indel realignment and BQSR. It can be run with any combination of normal and tumor samples (normal only, tumor only, normal-tumor paired, multiple normal and tumor samples).
 
+The pipeline now supports flexible processing modes:
+- **Both processes** (default): Run both indel realignment and base recalibration
+- **Indel realignment only**: Skip base recalibration step
+- **Base recalibration only**: Skip indel realignment and run BQSR directly on raw BAMs
+
 ---
 
 ## How To Run
@@ -90,6 +95,8 @@ Generate sha512 checksum for final BAM and BAI files.
 | Field | Type | Description |
 |:------|:-----|:------------|
 | patient_id | string | Patient ID (will be standardized according to data storage structure in the near future) |
+| run_indel_realignment | boolean | (Optional) Whether to run indel realignment. Default: true |
+| run_base_recalibration | boolean | (Optional) Whether to run base recalibration. Default: true |
 | normal_BAM | path | Set to absolute path to normal BAM |
 | tumor_BAM | path | Set to absolute path to tumour BAM |
 | recalibration_table | path | (Optional) Absolute path to recalibration table |
@@ -128,12 +135,58 @@ input:
 
 For normal-only or tumour-only samples, exclude the fields for the other state.
 
+#### Processing Mode Examples
+
+Run indel realignment only:
+```
+---
+patient_id: "patient_id"
+run_indel_realignment: true
+run_base_recalibration: false
+input:
+  BAM:
+    normal:
+      - "/absolute/path/to/BAM"
+    tumor:
+      - "/absolute/path/to/BAM"
+```
+
+Run base recalibration only:
+```
+---
+patient_id: "patient_id"
+run_indel_realignment: false
+run_base_recalibration: true
+input:
+  BAM:
+    normal:
+      - "/absolute/path/to/BAM"
+    tumor:
+      - "/absolute/path/to/BAM"
+```
+
+Run both processes (default behavior - parameters can be omitted):
+```
+---
+patient_id: "patient_id"
+run_indel_realignment: true
+run_base_recalibration: true
+input:
+  BAM:
+    normal:
+      - "/absolute/path/to/BAM"
+    tumor:
+      - "/absolute/path/to/BAM"
+```
+
 ### Config
 
 | Input Parameter | Required | Type | Description |
 |:----------------|:---------|:-----|:------------|
 | `dataset_id` | Yes | string | Dataset ID |
 | `blcds_registered_dataset` | Yes | boolean | Set to true when using BLCDS folder structure; use false for now |
+| `run_indel_realignment` | Yes | boolean | Whether to run indel realignment; defaults to true |
+| `run_base_recalibration` | Yes | boolean | Whether to run base recalibration; defaults to true |
 | `output_dir` | Yes | string | Need to set if `blcds_registered_dataset = false` |
 | `save_intermediate_files` | Yes | boolean | Set to false to disable publishing of intermediate files; true otherwise; disabling option will delete intermediate files to allow for processing of large BAMs |
 | `aligner` | Yes | string | Original aligner used to align input BAMs; formatted as \<aligner\>-\<aligner-version\> |

--- a/config/default.config
+++ b/config/default.config
@@ -7,6 +7,10 @@ params {
     min_cpus = 1
     min_memory = 1.MB
 
+    // Default values for pipeline execution modes
+    run_indel_realignment = true
+    run_base_recalibration = true
+
     gatk_command_mem_diff = 0.GB
     max_cpus   = SysHelper.getAvailCpus()
     max_memory = SysHelper.getAvailMemory()

--- a/config/methods.config
+++ b/config/methods.config
@@ -66,7 +66,6 @@ methods {
         Map custom_allocations = [:]
 
         def processes_to_parallelize_per_sample = [
-            'run_BaseRecalibrator_GATK',
             'run_MergeSamFiles_Picard',
             'deduplicate_records_SAMtools'
         ]

--- a/config/resources.json
+++ b/config/resources.json
@@ -37,6 +37,260 @@
             }
         }
     },
+    "f8": {
+        "run_validate_PipeVal": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
+            }
+        },
+        "extract_GenomeIntervals": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
+            }
+        },
+        "run_SplitIntervals_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
+            }
+        },
+        "run_RealignerTargetCreator_GATK": {
+            "cpus": {
+                "min": 2,
+                "fraction": 0.25,
+                "max": 2
+            },
+            "memory": {
+                "min": "4 GB",
+                "fraction": 0.26,
+                "max": "4 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_IndelRealigner_GATK": {
+            "cpus": {
+                "min": 2,
+                "fraction": 0.25,
+                "max": 2
+            },
+            "memory": {
+                "min": "4 GB",
+                "fraction": 0.25,
+                "max": "4 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 4
+                }
+            }
+        },
+        "run_BaseRecalibrator_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "30 GB",
+                "fraction": 0.99,
+                "max": "30 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_ApplyBQSR_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "2 GB",
+                "fraction": 0.14,
+                "max": "2 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 4
+                }
+            }
+        },
+        "run_MergeSamFiles_Picard": {
+            "cpus": {
+                "min": 2,
+                "fraction": 0.25,
+                "max": 2
+            },
+            "memory": {
+                "min": "8 GB",
+                "fraction": 0.52,
+                "max": "8 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "deduplicate_records_SAMtools": {
+            "cpus": {
+                "min": 2,
+                "fraction": 0.25,
+                "max": 2
+            },
+            "memory": {
+                "min": "8 GB",
+                "fraction": 0.52,
+                "max": "8 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_index_SAMtools": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "2 GB",
+                "fraction": 0.14,
+                "max": "2 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_GetPileupSummaries_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "5 GB",
+                "fraction": 0.32,
+                "max": "5 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_CalculateContamination_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "5 GB",
+                "fraction": 0.32,
+                "max": "5 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_DepthOfCoverage_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "5 GB",
+                "fraction": 0.32,
+                "max": "5 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "remove_intermediate_files": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
+            }
+        },
+        "remove_unmerged_BAMs": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
+            }
+        },
+        "remove_merged_BAM": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
+            }
+        }
+    },
     "f16": {
         "run_validate_PipeVal": {
             "cpus": {

--- a/config/resources.json
+++ b/config/resources.json
@@ -117,9 +117,27 @@
                 "max": 1
             },
             "memory": {
-                "min": "30 GB",
-                "fraction": 0.99,
-                "max": "30 GB"
+                "min": "1 GB",
+                "fraction": 0.0625,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.06,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
@@ -371,14 +389,32 @@
                 "max": 1
             },
             "memory": {
-                "min": "30 GB",
-                "fraction": 0.99,
-                "max": "30 GB"
+                "min": "1 GB",
+                "fraction": 0.03125,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.06,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.03,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
                 }
             }
         },
@@ -625,9 +661,27 @@
                 "max": 1
             },
             "memory": {
-                "min": "60 GB",
-                "fraction": 0.99,
-                "max": "60 GB"
+                "min": "1 GB",
+                "fraction": 0.015625,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.03,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.02,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
@@ -879,9 +933,27 @@
                 "max": 1
             },
             "memory": {
-                "min": "72 GB",
-                "fraction": 0.53,
-                "max": "72 GB"
+                "min": "2 GB",
+                "fraction": 0.00694,
+                "max": "2 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.01,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
@@ -1133,9 +1205,27 @@
                 "max": 1
             },
             "memory": {
-                "min": "500 GB",
-                "fraction": 0.51,
-                "max": "500 GB"
+                "min": "20 GB",
+                "fraction": 0.02,
+                "max": "20 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.02,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.00,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
@@ -1352,8 +1442,26 @@
             },
             "memory": {
                 "min": "1 GB",
-                "fraction": 0.53,
-                "max": "72 GB"
+                "fraction": 0.02,
+                "max": "20 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "exponential",
+                    "operand": 2
+                }
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.01,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -11,6 +11,16 @@ aligner:
   type: 'AlignerTool'
   required: true
   help: 'Aligner used to align input BAMs. Provided as <Aligner>-<Aligner-version>'
+run_indel_realignment:
+  type: 'Bool'
+  required: true
+  default: true
+  help: 'Whether to run indel realignment'
+run_base_recalibration:
+  type: 'Bool'
+  required: true
+  default: true
+  help: 'Whether to run base recalibration'
 output_dir:
   type: 'Path'
   mode: 'w'

--- a/main.nf
+++ b/main.nf
@@ -239,7 +239,8 @@ workflow {
                     'bam_index': sample.index,
                     'interval_id': interval.interval_id,
                     'interval': interval.interval_path,
-                    'has_unmapped': (interval.interval_id == 'nonassembled' || interval.interval_id == '0000')
+                    'has_unmapped': (interval.interval_id == 'nonassembled' || interval.interval_id == '0000'),
+                    'sample_id': sample.id  // Preserve sample ID with each BAM
                 ]
             }
             .set{ raw_bam_input }

--- a/main.nf
+++ b/main.nf
@@ -247,8 +247,6 @@ workflow {
     merge_bams(samples_for_merge)
 
 
-    /**
-    *   Summary and QC processes
     merge_bams.out.output_ch_merge_bams
         .map{ [it.sample, it.bam, it.bam_index] }
         .set{ input_ch_merged_bams }
@@ -316,6 +314,5 @@ workflow {
         input_ch_summary_intervals,
         input_ch_merged_bams
     )
-    */
 }
 

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -215,7 +215,7 @@ workflow recalibrate_base {
                 it[0].interval_id,
                 it[0].interval,
                 it[0].has_unmapped,
-                it[1].ids,
+                it[0].sample_id ? [it[0].sample_id] : it[1].ids,  // Use specific sample ID if available, otherwise all IDs
                 it[1].tables
             ]
         }

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -204,11 +204,11 @@ workflow recalibrate_base {
             def sample_id
 
             if (sample_data.containsKey('sample_id')) {
-                // Base recalibration only mode - sample ID is provided
+                // Both base recalibration only mode and indel realignment mode now provide sample_id
                 sample_id = sample_data.sample_id
             } else {
-                // Indel realignment mode - extract from standardized BAM filename
-                sample_id = sample_data.bam.baseName.split("_")[3]
+                // Fallback - this should not happen with the new implementation
+                throw new Exception("Sample ID not found in input data: ${sample_data}")
             }
 
             return [

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -25,7 +25,7 @@ include {
         input_bams: list or tuple of paths to input BAMs (raw or indel realigned)
         input_bams_bai: list or tuple of paths to input BAM indices
         sample_id: identifier for the sample
-        
+
     params:
         params.output_dir_base: string(path)
         params.log_output_dir: string(path)
@@ -33,14 +33,16 @@ include {
         params.docker_image_gatk: string
         params.is_targeted: bool. Indicator of whether in targeted exome mode or in WGS mode
         params.gatk_command_mem_diff: float(memory)
+        params.run_indel_realignment: bool. Indicator of whether to run indel realignment
 */
 process run_BaseRecalibrator_GATK {
     container params.docker_image_gatk
-    publishDir path: "${params.output_dir_base}/QC/${task.process.replace(':', '/')}",
+    publishDir path: "${params.output_dir_base}/intermediate/${task.process.replace(':', '/')}",
       mode: "copy",
+      enabled: params.save_intermediate_files,
       pattern: "*.grp"
 
-    ext log_dir_suffix: { "-${sample_id}" }
+    ext log_dir_suffix: { "-${sample_id}-${interval_id}" }
 
     input:
     path(reference_fasta)
@@ -52,33 +54,74 @@ process run_BaseRecalibrator_GATK {
     path(bundle_known_indels_vcf_gz_tbi)
     path(bundle_v0_dbsnp138_vcf_gz)
     path(bundle_v0_dbsnp138_vcf_gz_tbi)
-    path(intervals)
-    path(recal_tables)
-    tuple path(input_bams), path(input_bams_bai), val(sample_id)
+    tuple path(input_bam),
+          path(input_bam_index),
+          val(interval_id),
+          path(interval),
+          val(includes_unmapped),
+          val(sample_id)
 
     output:
-    tuple val(sample_id), path("${sample_id}_recalibration_table.grp"), emit: recalibration_table
+    tuple val(sample_id), val(interval_id), path("${sample_id}_${interval_id}_recalibration_table.grp"), emit: recalibration_table
 
     script:
-    all_input_bams = input_bams.collect{ "--input '${it}'" }.join(' ')
-    targeted_options = params.is_targeted ? "--intervals \"\$(realpath ${intervals})\" --interval-padding 100" : ""
+    unmapped_interval_option = (includes_unmapped) ? "--intervals unmapped" : ""
+    combined_interval_options = "--intervals ${interval} ${unmapped_interval_option}"
+    targeted_options = params.is_targeted ? "--interval-padding 100" : ""
     """
     set -euo pipefail
-    if [ ! -f ${sample_id}_recalibration_table.grp ]
-    then
-        gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \
-            BaseRecalibrator \
-            ${all_input_bams} \
-            --reference ${reference_fasta} \
-            --verbosity INFO \
-            --known-sites ${bundle_mills_and_1000g_gold_standard_indels_vcf_gz} \
-            --known-sites ${bundle_known_indels_vcf_gz} \
-            --known-sites ${bundle_v0_dbsnp138_vcf_gz} \
-            --output ${sample_id}_recalibration_table.grp \
-            ${targeted_options} \
-            --read-filter SampleReadFilter \
-            --sample ${sample_id}
-    fi
+    gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \
+        BaseRecalibrator \
+        --input ${input_bam} \
+        --reference ${reference_fasta} \
+        --verbosity INFO \
+        --known-sites ${bundle_mills_and_1000g_gold_standard_indels_vcf_gz} \
+        --known-sites ${bundle_known_indels_vcf_gz} \
+        --known-sites ${bundle_v0_dbsnp138_vcf_gz} \
+        --output ${sample_id}_${interval_id}_recalibration_table.grp \
+        ${combined_interval_options} \
+        ${targeted_options} \
+        --read-filter SampleReadFilter \
+        --sample ${sample_id}
+    """
+}
+
+/*
+    Nextflow module for gathering BQSR reports from multiple intervals into a single report per sample
+
+    input:
+        sample_id: identifier for the sample
+        recalibration_tables: list of paths to interval-specific recalibration tables for this sample
+
+    params:
+        params.output_dir_base: string(path)
+        params.log_output_dir: string(path)
+        params.docker_image_gatk: string
+        params.gatk_command_mem_diff: float(memory)
+*/
+process run_GatherBQSRReports_GATK {
+    container params.docker_image_gatk
+    publishDir path: "${params.output_dir_base}/QC/${task.process.replace(':', '/')}",
+      mode: "copy",
+      pattern: "*.grp"
+
+    ext log_dir_suffix: { "-${sample_id}" }
+
+    input:
+    tuple val(sample_id), path(recalibration_tables)
+
+    output:
+    tuple val(sample_id), path("${sample_id}_recalibration_table.grp"), emit: gathered_recalibration_table
+
+    script:
+    input_args = recalibration_tables.collect{ "--input ${it}" }.join(' ')
+    """
+    set -euo pipefail
+
+    gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \
+        GatherBQSRReports \
+        ${input_args} \
+        --output ${sample_id}_recalibration_table.grp
     """
 }
 
@@ -89,12 +132,12 @@ process run_BaseRecalibrator_GATK {
         reference_fasta: path to reference genome fasta file
         reference_fasta_fai: path to index for reference fasta
         reference_fasta_dict: path to dictionary for reference fasta
-        input_bam: list or tuple of paths to input BAMs (raw or indel realigned)
-        input_bam_index: list or tuple of paths to input BAM indices
+        input_bam: path to input BAM (raw or indel realigned)
+        input_bam_index: path to input BAM index
         interval: path to specific intervals file associated with input BAM
         includes_unmapped: boolean to indicate if unmapped reads are included in input BAM
         sample_id: Identifier for sample being processed
-        recalibration_table: path to base recalibration table
+        recalibration_table: path to gathered base recalibration table
 
     params:
         params.output_dir_base: string(path)
@@ -111,7 +154,7 @@ process run_ApplyBQSR_GATK {
       enabled: params.save_intermediate_files,
       pattern: "*_recalibrated-*"
 
-    ext log_dir_suffix: { "-${interval_id}" }
+    ext log_dir_suffix: { "-${sample_id}-${interval_id}" }
 
     input:
     path(reference_fasta)
@@ -132,57 +175,54 @@ process run_ApplyBQSR_GATK {
     script:
     unmapped_interval_option = (includes_unmapped) ? "--intervals unmapped" : ""
     combined_interval_options = "--intervals ${interval} ${unmapped_interval_option}"
-    all_commands = sample_id.collect{
-        """
-        gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \\
-            ApplyBQSR \\
-            --input ${input_bam} \\
-            --bqsr-recal-file ${it}_recalibration_table.grp \\
-            --reference ${reference_fasta} \\
-            --read-filter SampleReadFilter \\
-            ${combined_interval_options} \\
-            --emit-original-quals ${params.is_emit_original_quals} \\
-            --output /dev/stdout \\
-            --sample ${it} 2> .command.err | \\
-            samtools view -h | \\
-            awk '(/^@RG/ && /SM:${it}/) || ! /^@RG/' | \\
-            samtools view -b -o ${generate_standard_filename(params.aligner, params.dataset_id, it, ['additional_tools': ["GATK-${params.gatk_version}"]])}_recalibrated-${interval_id}.bam
-        """
-        }
-        .join("\n")
     """
     set -euo pipefail
-    ${all_commands}
+    gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \
+        ApplyBQSR \
+        --input ${input_bam} \
+        --bqsr-recal-file ${recalibration_table} \
+        --reference ${reference_fasta} \
+        --read-filter SampleReadFilter \
+        ${combined_interval_options} \
+        --emit-original-quals ${params.is_emit_original_quals} \
+        --output /dev/stdout \
+        --sample ${sample_id} 2> .command.err | \
+        samtools view -h | \
+        awk '(/^@RG/ && /SM:${sample_id}/) || ! /^@RG/' | \
+        samtools view -b -o ${generate_standard_filename(params.aligner, params.dataset_id, sample_id, ['additional_tools': ["GATK-${params.gatk_version}"]])}_recalibrated-${interval_id}.bam
     """
 }
 
 workflow recalibrate_base {
     take:
-    input_samples
-    sample_ids
+    input_samples  // Channel of sample data with BAM, index, interval info, and sample_id
 
     main:
+    // Extract sample ID from BAM for each sample - handle both modes
     input_samples
-        .reduce( ['bams': [], 'indices': []] ){ a, b ->
-            // Only add unique BAM files to avoid collisions (for base recalibration only mode)
-            if (!a.bams.contains(b.bam)) {
-                a.bams.add(b.bam);
-                a.indices.add(b.bam_index);
+        .map{ sample_data ->
+            def sample_id
+
+            if (sample_data.containsKey('sample_id')) {
+                // Base recalibration only mode - sample ID is provided
+                sample_id = sample_data.sample_id
+            } else {
+                // Indel realignment mode - extract from standardized BAM filename
+                sample_id = sample_data.bam.baseName.split("_")[3]
             }
-            return a
-        }
-        .combine(sample_ids)
-        .map{ it ->
-            [
-                it[0].bams,
-                it[0].indices,
-                it[1]
+
+            return [
+                sample_data.bam,
+                sample_data.bam_index,
+                sample_data.interval_id,
+                sample_data.interval,
+                sample_data.has_unmapped,
+                sample_id
             ]
         }
         .set{ input_ch_base_recalibrator }
 
-    base_recalibrator_intervals = (params.is_targeted) ? params.intervals : "/scratch/NO_FILE.interval_list"
-
+    // Run BaseRecalibrator in parallel for each interval and sample
     run_BaseRecalibrator_GATK(
         params.reference_fasta,
         params.reference_fasta_fai,
@@ -193,31 +233,28 @@ workflow recalibrate_base {
         params.bundle_known_indels_vcf_gz_tbi,
         params.bundle_v0_dbsnp138_vcf_gz,
         params.bundle_v0_dbsnp138_vcf_gz_tbi,
-        base_recalibrator_intervals,
-        params.input.recalibration_table,
         input_ch_base_recalibrator
     )
 
+    // Group recalibration tables by sample and gather them
     run_BaseRecalibrator_GATK.out.recalibration_table
-        .reduce( ['ids': [], 'tables': []] ){ a, b ->
-            a.ids.add(b[0]);
-            a.tables.add(b[1]);
-            return a
-        }
-        .set{ all_recal_tables }
+        .map{ sample_id, interval_id, table -> [sample_id, table] }
+        .groupTuple()
+        .set{ grouped_recal_tables }
 
-    input_samples
-        .combine(all_recal_tables)
-        .map{ it ->
-            [
-                it[0].bam,
-                it[0].bam_index,
-                it[0].interval_id,
-                it[0].interval,
-                it[0].has_unmapped,
-                it[0].sample_id ? [it[0].sample_id] : it[1].ids,  // Use specific sample ID if available, otherwise all IDs
-                it[1].tables
-            ]
+    run_GatherBQSRReports_GATK(grouped_recal_tables)
+
+    // Combine input samples with their gathered recalibration tables
+    input_ch_base_recalibrator
+        .map{ bam, bam_index, interval_id, interval, has_unmapped, sample_id ->
+            [sample_id, [bam, bam_index, interval_id, interval, has_unmapped, sample_id]]
+        }
+        .combine(
+            run_GatherBQSRReports_GATK.out.gathered_recalibration_table,
+            by: 0  // Join by sample_id
+        )
+        .map{ sample_id, sample_data, gathered_table ->
+            sample_data + [gathered_table]  // Add the gathered table path (gathered_table is already just the path)
         }
         .set{ input_ch_apply_bqsr }
 
@@ -238,17 +275,18 @@ workflow recalibrate_base {
         }
         .set{ output_ch_base_recalibration }
 
-    // Only remove intermediate files if they're not original input files
-    // Check if the files are from indel realignment (contain "indelrealigned") or original inputs
-    run_ApplyBQSR_GATK.out.output_ch_deletion
-        .flatten()
-        .filter{ file -> 
-            // Only delete if filename contains "indelrealigned" (intermediate files)
-            // Skip deletion of original input BAMs in base recalibration only mode
-            file.name.contains("indelrealigned")
-        }
-        .set{ files_to_delete }
-    
+    // Handle intermediate file deletion
+    // Only delete files if they came from indel realignment (not original input BAMs)
+    if (params.run_indel_realignment) {
+        // Indel realignment was run, safe to delete intermediate files
+        run_ApplyBQSR_GATK.out.output_ch_deletion
+            .flatten()
+            .set{ files_to_delete }
+    } else {
+        // Base recalibration only mode - don't delete original input BAMs
+        Channel.empty().set{ files_to_delete }
+    }
+
     remove_intermediate_files(
         files_to_delete,
         "bqsr_complete"

--- a/nftest.yml
+++ b/nftest.yml
@@ -24,3 +24,12 @@ cases:
       - actual: recalibrate-BAM-*/TWGSAMIN000001/GATK-*/output/BWA-MEM2-*_GATK-*_A-mini_S2-v1.1.5.bam.bai.sha512
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.bai.sha512
         method: md5
+      - actual: recalibrate-BAM-*/TWGSAMIN000001/GATK-*/QC/S2_v1.1.5_recalibration_table.grp
+        expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/S2_v1.1.5_recalibration_table.grp
+        method: md5
+
+  - name: A-mini-n2-recal-only
+    nf_script: ./main.nf
+    params_file: ./test/single-recal-only.yaml
+    skip: true
+    verbose: true

--- a/nftest.yml
+++ b/nftest.yml
@@ -24,7 +24,7 @@ cases:
       - actual: recalibrate-BAM-*/TWGSAMIN000001/GATK-*/output/BWA-MEM2-*_GATK-*_A-mini_S2-v1.1.5.bam.bai.sha512
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.bai.sha512
         method: md5
-      - actual: recalibrate-BAM-*/TWGSAMIN000001/GATK-*/QC/S2_v1.1.5_recalibration_table.grp
+      - actual: recalibrate-BAM-*/TWGSAMIN000001/GATK-*/QC/recalibrate_base/run_GatherBQSRReports_GATK/S2_v1.1.5_recalibration_table.grp
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/S2_v1.1.5_recalibration_table.grp
         method: md5
 

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -78,7 +78,7 @@
         },
         "run_BaseRecalibrator_GATK": {
           "cpus": "1",
-          "memory": "27.9 GB"
+          "memory": "1 GB"
         },
         "run_CalculateContamination_GATK": {
           "cpus": "1",
@@ -87,6 +87,10 @@
         "run_DepthOfCoverage_GATK": {
           "cpus": "1",
           "memory": "14 GB"
+        },
+        "run_GatherBQSRReports_GATK": {
+          "cpus": "1",
+          "memory": "1 GB"
         },
         "run_GetPileupSummaries_GATK": {
           "cpus": "1",
@@ -188,8 +192,8 @@
         },
         "run_BaseRecalibrator_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "1 GB",
+            "strategy": "add"
           }
         },
         "run_CalculateContamination_GATK": {
@@ -202,6 +206,12 @@
           "memory": {
             "operand": "2",
             "strategy": "exponential"
+          }
+        },
+        "run_GatherBQSRReports_GATK": {
+          "memory": {
+            "operand": "1 GB",
+            "strategy": "add"
           }
         },
         "run_GetPileupSummaries_GATK": {
@@ -235,6 +245,8 @@
           }
         }
       },
+      "run_base_recalibration": true,
+      "run_indel_realignment": true,
       "samples_to_process": [
         {
           "id": "4915723",
@@ -243,7 +255,7 @@
         }
       ],
       "samtools_version": "1.17",
-      "save_intermediate_files": false,
+      "save_intermediate_files": true,
       "scatter_count": "50",
       "split_intervals_extra_args": "",
       "ucla_cds": true,
@@ -373,10 +385,10 @@
       "withName:run_BaseRecalibrator_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "27.9 GB",
-          "2": "31 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(27.9 GB, exponential, 2, $task.attempt, memory)"
+          "1": "1 GB",
+          "2": "2 GB",
+          "3": "3 GB",
+          "closure": "retry_updater(1 GB, add, 1 GB, $task.attempt, memory)"
         }
       },
       "withName:run_CalculateContamination_GATK": {
@@ -395,6 +407,15 @@
           "2": "27.9 GB",
           "3": "31 GB",
           "closure": "retry_updater(14 GB, exponential, 2, $task.attempt, memory)"
+        }
+      },
+      "withName:run_GatherBQSRReports_GATK": {
+        "cpus": "1",
+        "memory": {
+          "1": "1 GB",
+          "2": "2 GB",
+          "3": "3 GB",
+          "closure": "retry_updater(1 GB, add, 1 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GetPileupSummaries_GATK": {

--- a/test/configtest-F32.json
+++ b/test/configtest-F32.json
@@ -78,7 +78,7 @@
         },
         "run_BaseRecalibrator_GATK": {
           "cpus": "1",
-          "memory": "57.6 GB"
+          "memory": "1 GB"
         },
         "run_CalculateContamination_GATK": {
           "cpus": "1",
@@ -87,6 +87,10 @@
         "run_DepthOfCoverage_GATK": {
           "cpus": "1",
           "memory": "28.8 GB"
+        },
+        "run_GatherBQSRReports_GATK": {
+          "cpus": "1",
+          "memory": "1 GB"
         },
         "run_GetPileupSummaries_GATK": {
           "cpus": "1",
@@ -188,8 +192,8 @@
         },
         "run_BaseRecalibrator_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "1 GB",
+            "strategy": "add"
           }
         },
         "run_CalculateContamination_GATK": {
@@ -199,6 +203,12 @@
           }
         },
         "run_DepthOfCoverage_GATK": {
+          "memory": {
+            "operand": "2",
+            "strategy": "exponential"
+          }
+        },
+        "run_GatherBQSRReports_GATK": {
           "memory": {
             "operand": "2",
             "strategy": "exponential"
@@ -235,6 +245,8 @@
           }
         }
       },
+      "run_base_recalibration": true,
+      "run_indel_realignment": true,
       "samples_to_process": [
         {
           "id": "4915723",
@@ -243,7 +255,7 @@
         }
       ],
       "samtools_version": "1.17",
-      "save_intermediate_files": false,
+      "save_intermediate_files": true,
       "scatter_count": "50",
       "split_intervals_extra_args": "",
       "ucla_cds": true,
@@ -373,10 +385,10 @@
       "withName:run_BaseRecalibrator_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "57.6 GB",
-          "2": "64 GB",
-          "3": "64 GB",
-          "closure": "retry_updater(57.6 GB, exponential, 2, $task.attempt, memory)"
+          "1": "1 GB",
+          "2": "2 GB",
+          "3": "3 GB",
+          "closure": "retry_updater(1 GB, add, 1 GB, $task.attempt, memory)"
         }
       },
       "withName:run_CalculateContamination_GATK": {
@@ -395,6 +407,15 @@
           "2": "57.6 GB",
           "3": "64 GB",
           "closure": "retry_updater(28.8 GB, exponential, 2, $task.attempt, memory)"
+        }
+      },
+      "withName:run_GatherBQSRReports_GATK": {
+        "cpus": "1",
+        "memory": {
+          "1": "1 GB",
+          "2": "2 GB",
+          "3": "4 GB",
+          "closure": "retry_updater(1 GB, exponential, 2, $task.attempt, memory)"
         }
       },
       "withName:run_GetPileupSummaries_GATK": {

--- a/test/nftest.config
+++ b/test/nftest.config
@@ -13,7 +13,7 @@ params {
 
     // Set to false to disable the publish rule and delete intermediate files as they're no longer needed
     // Disable this option for large input BAMs where /scratch space may not be sufficient
-    save_intermediate_files = false
+    save_intermediate_files = true
 
     // Original aligner used to align BAMs
     // Provided as <aligner>-<aligner-version>

--- a/test/single-recal-only.yaml
+++ b/test/single-recal-only.yaml
@@ -1,0 +1,8 @@
+---
+patient_id: TWGSAMIN000001
+run_indel_realignment: false
+run_base_recalibration: true
+input:
+  BAM:
+    tumor:
+      - "/hot/data/unregistered/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam"


### PR DESCRIPTION
# Description
### Add Tool Choice AND Parallelize BaseRecalibrator

## Add Tool Choice
This PR introduces flexible processing modes for the recalibrate-BAM pipeline, allowing users to selectively run indel realignment and/or base recalibration steps instead of always running both.

##Closes #9 
#### New Features
- **Selective Processing**: Users can now choose to run:
  - Both indel realignment and base recalibration (default behavior)
  - Indel realignment only (skip BQSR)
  - Base recalibration only (skip indel realignment, run BQSR directly on raw BAMs)

- **Parameter Validation**: Added validation to ensure at least one processing step is selected

- **Enhanced Resource Management**: Updated resource configurations for all processing modes across different compute environments (F2, F8, F16, F32)

#### Configuration Changes
**New Parameters:**
- `run_indel_realignment` (boolean, default: true) - Whether to run indel realignment
- `run_base_recalibration` (boolean, default: true) - Whether to run base recalibration

**Usage Examples:**
```
# Default: Run both steps
run_indel_realignment: true
run_base_recalibration: true

# Indel realignment only
run_indel_realignment: true
run_base_recalibration: false

# Base recalibration only  
run_indel_realignment: false
run_base_recalibration: true
```

#### Technical Changes
- **Schema Updates**: Added new boolean parameters with validation
- **Workflow Logic**: Implemented conditional processing with proper channel handling
- **Module Updates**: Enhanced base-recalibration module to support flexible input sources
- **Resource Optimization**: Comprehensive resource configurations for all compute tiers
- **Documentation**: Updated README with usage examples and parameter descriptions

#### Benefits
- **Flexibility**: Supports different analysis workflows and requirements
- **Efficiency**: Allows skipping unnecessary steps to save compute time
- **Backwards Compatible**: Default behavior unchanged (both steps run)
- **Resource Optimized**: Proper resource allocation for each processing mode


## Parallelize BaseRecalibrator Processing for Improved Performance
### Closes #94

### Overview
This PR introduces parallelization of the BaseRecalibrator step in the recalibrate-BAM pipeline, significantly improving processing performance for large datasets by leveraging interval-based parallel processing.

### Key Changes

#### 🚀 **Performance Improvements**
- **Parallelized BaseRecalibrator execution**: BaseRecalibrator now runs in parallel across genomic intervals instead of sequentially on whole genomes
- **Interval-based processing**: Each interval generates its own recalibration table, enabling concurrent processing
- **Automatic table gathering**: Individual interval tables are automatically merged using `GatherBQSRReports` 
- **Parallel BQSR application**: ApplyBQSR also runs in parallel across intervals for consistent performance gains

#### 🔧 **Technical Implementation**
- **Enhanced workflow orchestration**: Modified `module/base-recalibration.nf` to handle interval-based parallelization
- **Sample ID preservation**: Improved sample ID handling throughout the parallel processing pipeline
- **Resource optimization**: Updated `config/resources.json` with optimized memory and CPU allocations for parallel processes
- **Interval management**: Enhanced interval splitting and processing logic in `main.nf`

#### 🛠️ **Process Flow**
1. **Split intervals**: Genome is split into intervals (by chromosome or scatter count)
2. **Parallel BaseRecalibrator**: Each interval runs BaseRecalibrator independently
3. **Gather reports**: `GatherBQSRReports` combines interval-specific recalibration tables
4. **Parallel ApplyBQSR**: BQSR application runs in parallel across intervals
5. **Merge results**: Final BAM merging consolidates interval-level outputs

### Benefits
- **Faster processing**: Dramatic reduction in runtime for large BAM files through parallel processing
- **Better resource utilization**: More efficient use of available CPU cores and memory
- **Scalability**: Performance scales with available compute resources
- **Backward compatibility**: Existing configurations continue to work without modification

### Testing
- Updated test configurations (`nftest.yml`, `test/nftest.config`) to validate parallel processing
- Verified compatibility with both chromosome-based and scatter-count-based interval splitting
- Confirmed proper handling of both single and multi-sample inputs

### Configuration
The parallelization is controlled by existing parameters:
- `parallelize_by_chromosome`: Enable chromosome-based parallelization
- `scatter_count`: Number of intervals when not using chromosome-based splitting
- Resource allocations automatically optimized for parallel processing

---

This parallelization represents a significant performance improvement for the recalibrate-BAM pipeline, particularly beneficial for large-scale genomic processing


## Testing Results


- NFTest -recalibration only
  - log:  `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/1.0.2/sfitz-add-tool-choice/log-nftest-20250703T235014Z.log`
  - output: `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/1.0.2/sfitz-add-tool-choice/A-mini-n2-recal-only`
- NFTest - default
  - log:`/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/1.0.2/sfitz-add-tool-choice/slurm-339411.out`
  - output: `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/1.0.2/sfitz-add-tool-choice/A-mini-n2`
  - cases:    default set 

**older logs below, with potential sample ID issue**
- Indel Realignment Only
  - sample:    A-mini
  - input yaml: /hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-recalibrate-BAM/development-extras/yaml/amin.yaml
  - config:    /hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-recalibrate-BAM/development-extras/config/indel_realignment_only.config
  - output:    /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/1.0.2/sfitz-add-tool-choice/amin-indel_realignment_only
  - log: /hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-recalibrate-BAM/development-extras/amin-logs/slurm-336566.out

- Recalibration Only
  - sample:    A-mini
  - input yaml: /hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-recalibrate-BAM/development-extras/yaml/amin.yaml
  - config:    /hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-recalibrate-BAM/development-extras/config/recalibrate_only.config
  - output:    /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/1.0.2/sfitz-add-tool-choice/amin-recalibrate_only
  - log: /hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-recalibrate-BAM/development-extras/amin-logs/slurm-336565.out

# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
