### PR TITLE
Tool choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Replace node-specific configs with computed `resources.json` file
 - Use `resource_handler.handle_resources()`
 - Output per-sample BAMs from IndelRealignment using `--nWayOut`
-- Run `ApplyBQSR` per-sample rather than per-interval
+- Run `ApplyBQSR` per-sample and per-interval rather than just per-interval
 
 ## [1.0.2] - 2024-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## Added
+
+- Options for selecting combination of BQSR and IndelRealignment
+
 ### Changed
 
 - Update to branch of `pipeline-Nextflow-config`
 - Replace node-specific configs with computed `resources.json` file
 - Use `resource_handler.handle_resources()`
+- Output per-sample BAMs from IndelRealignment using `--nWayOut`
+- Run `ApplyBQSR` per-sample rather than per-interval
 
 ## [1.0.2] - 2024-10-08
 

--- a/config/default.config
+++ b/config/default.config
@@ -18,6 +18,9 @@ params {
     metapipeline_delete_input_bams = false
     metapipeline_states_to_delete = ['normal', 'tumor']
 
+    run_indelrealignment = true
+    run_bqsr = true
+
     docker_container_registry = "ghcr.io/uclahs-cds"
 
     gatk_version = "4.2.4.1"

--- a/config/methods.config
+++ b/config/methods.config
@@ -105,6 +105,12 @@ methods {
         }
     }
 
+    validate_selection = {
+        if (!(params.run_bqsr || params.run_indelrealignment)) {
+            throw new Exception("At least one of BQSR and IndelRealignment must be enabled using params: `run_bqsr` and `run_indelrealignment`.")
+        }
+    }
+
     setup = {
         methods.set_env()
         schema.load_custom_types("${projectDir}/config/custom_schema_types.config")

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -26,6 +26,16 @@ is_emit_original_quals:
   required: true
   default: true
   help: 'Whether to emit original quality scores after recalibration'
+run_bqsr:
+  type: 'Bool'
+  required: true
+  default: true
+  help: 'Whether to run BQSR'
+run_indelrealignment:
+  type: 'Bool'
+  required: true
+  default: true
+  help: 'Whether to run IndelRealignment'
 is_DOC_run:
   type: 'Bool'
   required: true

--- a/main.nf
+++ b/main.nf
@@ -219,7 +219,7 @@ workflow {
     /**
     *   Merge BAMs
     */
-    merge_bams(recalibrate_base.out.recalibrated_samples)
+    merge_bams(output_ch_bqsr)
 
 
     /**

--- a/main.nf
+++ b/main.nf
@@ -163,10 +163,6 @@ workflow {
         output_ch_ir = realign_indels.out.output_ch_realign_indels
 
         realign_indels.out.output_ch_realign_indels
-            .combine(input_ch_sample_ids)
-            .map{ ir_combined ->
-                ir_combined[0] + ['id': ir_combined[1]]
-            }
             .set{ output_ch_ir }
 
         /**

--- a/main.nf
+++ b/main.nf
@@ -209,8 +209,10 @@ workflow {
             output_ch_ir
         )
 
+        output_ch_bqsr = recalibrate_base.out.recalibrated_samples
     } else {
-        // Reformat channels to match expected output of BQSR
+        // Pass through IR output channel since formats now match
+        output_ch_bqsr = output_ch_ir
     }
 
 

--- a/main.nf
+++ b/main.nf
@@ -132,6 +132,10 @@ workflow {
                 'interval_path': interval_path
             ]
         }
+        .map{ interval_data ->
+            interval_data['has_unmapped'] = (interval_data.interval_id == 'nonassembled' || interval_data.interval_id == '0000');
+            return interval_data;
+        }
         .set{ input_ch_intervals }
 
 

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -127,7 +127,7 @@ process run_ApplyBQSR_GATK {
           path(recalibration_table)
 
     output:
-    tuple val(sample_id), path(output_filename), path("${output_filename}.bai"), val(interval_id), val(interval), val(includes_unmapped), emit: output_ch_apply_bqsr
+    tuple val(sample_id), path(output_filename), val(interval_id), val(interval), val(includes_unmapped), emit: output_ch_apply_bqsr
     tuple path(input_bam), path(input_bam_index), emit: output_ch_deletion
 
     script:
@@ -168,14 +168,14 @@ workflow recalibrate_base {
     main:
     input_samples
         .map{ ir_sample ->
-            [it_sample.id, ir_sample.bam, it_sample.bam_index]
+            [ir_sample.id, ir_sample.bam, ir_sample.bam_index]
         }
         .groupTuple(by: 0)
         .map{ ir_grouped ->
             [
-                it[1].unique{ bam_path -> file(bam_path).getFileName() },
-                it[2].unique{ bam_index -> file(bam_index).getFileName() },
-                it[0]
+                ir_grouped[1].unique{ bam_path -> file(bam_path).getFileName() },
+                ir_grouped[2].unique{ bam_index -> file(bam_index).getFileName() },
+                ir_grouped[0]
             ]
         }
         .set{ input_ch_base_recalibrator }
@@ -216,7 +216,7 @@ workflow recalibrate_base {
         .set{ ided_input_samples }
 
     ided_recal_tables
-        .join(ided_input_samples)
+        .combine(ided_input_samples, by: 0)
         .map{ joined_input ->
             [
                 joined_input[2].bam,
@@ -244,7 +244,7 @@ workflow recalibrate_base {
             [
                 'id': bqsred_sample[0],
                 'bam': bqsred_sample[1],
-                'bam_index': bqsred_sample[2],
+                'bam_index': "/scratch/NO_INDEX.bai",
                 'interval_id': bqsred_sample[3],
                 'interval_path': bqsred_sample[4],
                 'has_unmapped': bqsred_sample[5]

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -8,6 +8,7 @@ include {
             log_output_dir: "${params.log_output_dir}/process-log"
             ]
         )
+include { delete_input } from './delete-input.nf'
 /*
     Nextflow module for generating base recalibration table
 
@@ -89,8 +90,8 @@ process run_BaseRecalibrator_GATK {
         reference_fasta: path to reference genome fasta file
         reference_fasta_fai: path to index for reference fasta
         reference_fasta_dict: path to dictionary for reference fasta
-        indelrealigned_bam: list or tuple of paths to indel realigned BAMs
-        indelrealigned_bam_index: list or tuple of paths to indel realigned BAM indices
+        input_bam: path to input BAM
+        input_bam_index: path to input BAM index
         interval: path to specific intervals file associated with input BAM
         includes_unmapped: boolean to indicate if unmapped reads are included in input BAM
         sample_id: Identifier for sample being processed
@@ -111,14 +112,14 @@ process run_ApplyBQSR_GATK {
       enabled: params.save_intermediate_files,
       pattern: "*_recalibrated-*"
 
-    ext log_dir_suffix: { "-${interval_id}" }
+    ext log_dir_suffix: { "-${sample_id}-${interval_id}" }
 
     input:
     path(reference_fasta)
     path(reference_fasta_fai)
     path(reference_fasta_dict)
-    tuple path(indelrealigned_bam),
-          path(indelrealigned_bam_index),
+    tuple path(input_bam),
+          path(input_bam_index),
           val(interval_id),
           path(interval),
           val(includes_unmapped),
@@ -126,33 +127,37 @@ process run_ApplyBQSR_GATK {
           path(recalibration_table)
 
     output:
-    path("*_recalibrated-*"), emit: output_ch_apply_bqsr
-    tuple path(indelrealigned_bam), path(indelrealigned_bam_index), emit: output_ch_deletion
+    tuple val(sample_id), path(output_filename), path("${output_filename}.bai"), val(interval_id), val(interval), val(includes_unmapped), emit: output_ch_apply_bqsr
+    tuple path(input_bam), path(input_bam_index), emit: output_ch_deletion
 
     script:
     unmapped_interval_option = (includes_unmapped) ? "--intervals unmapped" : ""
     combined_interval_options = "--intervals ${interval} ${unmapped_interval_option}"
-    all_commands = sample_id.collect{
-        """
-        gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \\
-            ApplyBQSR \\
-            --input ${indelrealigned_bam} \\
-            --bqsr-recal-file ${it}_recalibration_table.grp \\
-            --reference ${reference_fasta} \\
-            --read-filter SampleReadFilter \\
-            ${combined_interval_options} \\
-            --emit-original-quals ${params.is_emit_original_quals} \\
-            --output /dev/stdout \\
-            --sample ${it} 2> .command.err | \\
-            samtools view -h | \\
-            awk '(/^@RG/ && /SM:${it}/) || ! /^@RG/' | \\
-            samtools view -b -o ${generate_standard_filename(params.aligner, params.dataset_id, it, ['additional_tools': ["GATK-${params.gatk_version}"]])}_recalibrated-${interval_id}.bam
-        """
-        }
-        .join("\n")
+    output_filename = generate_standard_filename(
+        params.aligner,
+        params.dataset_id,
+        it,
+        [
+            'additional_tools': ["GATK-${params.gatk_version}"],
+            'additional_information': "recalibrated-${interval_id}.bam"
+        ]
+    )
     """
     set -euo pipefail
-    ${all_commands}
+
+    gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=${workDir}" \
+        ApplyBQSR \
+        --input ${input_bam} \
+        --bqsr-recal-file ${recalibration_table} \
+        --reference ${reference_fasta} \
+        --read-filter SampleReadFilter \
+        ${combined_interval_options} \
+        --emit-original-quals ${params.is_emit_original_quals} \
+        --output /dev/stdout \
+        --sample ${sample_id} 2> .command.err | \
+        samtools view -h | \
+        awk '(/^@RG/ && /SM:${sample_id}/) || ! /^@RG/' | \
+        samtools view -b -o ${output_filename}
     """
 }
 
@@ -193,24 +198,35 @@ workflow recalibrate_base {
     )
 
     run_BaseRecalibrator_GATK.out.recalibration_table
-        .reduce( ['ids': [], 'tables': []] ){ a, b ->
-            a.ids.add(b[0]);
-            a.tables.add(b[1]);
-            return a
+        .map{ recal_table ->
+            [
+                recal_table[0], // Sample ID
+                ['recal_table': recal_table[1]]
+            ]
         }
-        .set{ all_recal_tables }
+        .set{ ided_recal_tables }
 
     input_samples
-        .combine(all_recal_tables)
-        .map{ it ->
+        .map{ input_sample ->
             [
-                it[0].bam,
-                it[0].bam_index,
-                it[0].interval_id,
-                it[0].interval,
-                it[0].has_unmapped,
-                it[1].ids,
-                it[1].tables
+                input_sample.id,
+                input_sample
+            ]
+        }
+        .set{ ided_input_samples }
+
+    ided_recal_tables
+        .join(ided_input_samples)
+        .map{ joined_input ->
+            [
+                joined_input[2].bam,
+                joined_input[2].bam_index,
+                joined_input[2].interval_id,
+                joined_input[2].interval_path,
+                joined_input[2].has_unmapped,
+                joined_input[2].id,
+                joined_input[1].recal_table
+
             ]
         }
         .set{ input_ch_apply_bqsr }
@@ -222,20 +238,51 @@ workflow recalibrate_base {
         input_ch_apply_bqsr
     )
 
+    // val(sample_id), path(output_filename), path("${output_filename}.bai"), val(interval_id), val(interval), val(includes_unmapped)
     run_ApplyBQSR_GATK.out.output_ch_apply_bqsr
-        .flatten()
-        .map{
+        .map{ bqsred_sample ->
             [
-                'sample': it.baseName.split("_")[3], // sample ID
-                'bam': it
+                'id': bqsred_sample[0],
+                'bam': bqsred_sample[1],
+                'bam_index': bqsred_sample[2],
+                'interval_id': bqsred_sample[3],
+                'interval_path': bqsred_sample[4],
+                'has_unmapped': bqsred_sample[5]
             ]
         }
         .set{ output_ch_base_recalibration }
 
-    remove_intermediate_files(
-        run_ApplyBQSR_GATK.out.output_ch_deletion.flatten(),
-        "bqsr_complete"
-    )
+    /**
+    *   Handle deletion
+    */
+    if (params.run_indelrealignment) {
+        // Delete input to BQSR as intermediate files
+        remove_intermediate_files(
+            run_ApplyBQSR_GATK.out.output_ch_deletion.flatten(),
+            "bqsr_complete"
+        )
+    } else {
+        // Pipeline inputs directly sent to BQSR, handle deletion based on metapipeline params
+        Channel.from(params.samples_to_process)
+            .filter{ params.metapipeline_states_to_delete.contains(it.sample_type) }
+            .map{ sample -> sample.path }
+            .flatten()
+            .unique()
+            .set{ input_bams_to_delete }
+
+        run_ApplyBQSR_GATK.out.output_ch_apply_bqsr
+            .map{ 'done' }
+            .collect()
+            .map{ 'done' }
+            .set{ bqsr_complete_signal }
+
+        input_bams_to_delete
+            .combine(bqsr_complete_signal)
+            .map{ it[0] }
+            .set{ input_ch_bams_to_delete }
+
+        delete_input(input_ch_bams_to_delete)
+    }
 
     emit:
     recalibrated_samples = output_ch_base_recalibration

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -136,7 +136,7 @@ process run_ApplyBQSR_GATK {
     output_filename = generate_standard_filename(
         params.aligner,
         params.dataset_id,
-        it,
+        sample_id,
         [
             'additional_tools': ["GATK-${params.gatk_version}"],
             'additional_information': "recalibrated-${interval_id}.bam"

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -245,9 +245,9 @@ workflow recalibrate_base {
                 'id': bqsred_sample[0],
                 'bam': bqsred_sample[1],
                 'bam_index': "/scratch/NO_INDEX.bai",
-                'interval_id': bqsred_sample[3],
-                'interval_path': bqsred_sample[4],
-                'has_unmapped': bqsred_sample[5]
+                'interval_id': bqsred_sample[2],
+                'interval_path': bqsred_sample[3],
+                'has_unmapped': bqsred_sample[4]
             ]
         }
         .set{ output_ch_base_recalibration }

--- a/module/indel-realignment.nf
+++ b/module/indel-realignment.nf
@@ -113,7 +113,7 @@ process run_IndelRealigner_GATK {
     tuple path("*${output_extension}.bam"), path("*${output_extension}.bai"), val(interval_id), path(scatter_intervals), val(has_unmapped), val(output_extension), emit: output_ch_indel_realignment
 
     script:
-    arg_bam = bam.collect{ "--input_file '$it'" }.join(' ')
+    arg_bam = bam.sort().collect{ "--input_file '$it'" }.join(' ')
     unmapped_interval_option = (has_unmapped) ? "--intervals unmapped" : ""
     combined_interval_options = "--intervals ${scatter_intervals} ${unmapped_interval_option}"
     output_extension = "indelrealigned-${interval_id}"

--- a/module/indel-realignment.nf
+++ b/module/indel-realignment.nf
@@ -129,7 +129,7 @@ process run_IndelRealigner_GATK {
         --knownAlleles ${bundle_known_indels_vcf_gz} \
         --allow_potentially_misencoded_quality_scores \
         --targetIntervals ${target_intervals_RTC} \
-        --nWayOut ${output_extension}.bam
+        --nWayOut ${output_extension}.bam \
         ${combined_interval_options}
     """
 }

--- a/module/merge-bam.nf
+++ b/module/merge-bam.nf
@@ -170,7 +170,7 @@ workflow merge_bams {
 
     main:
     bams_to_merge
-        .map{ [it.sample, it.bam] }
+        .map{ [it.id, it.bam] }
         .groupTuple()
         .set{ input_ch_merge }
 

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -235,6 +235,8 @@
           }
         }
       },
+      "run_bqsr": true,
+      "run_indelrealignment": true,
       "samples_to_process": [
         {
           "id": "4915723",

--- a/test/configtest-F32.json
+++ b/test/configtest-F32.json
@@ -235,6 +235,8 @@
           }
         }
       },
+      "run_bqsr": true,
+      "run_indelrealignment": true,
       "samples_to_process": [
         {
           "id": "4915723",


### PR DESCRIPTION
# Description
<!-- Briefly describe the changes included in this pull request, starting with 'Closes #... if appropriate.  -->

Options to select which of BQSR and IndelRealignment to run. Updating IndelRealigner to output with `--nWayOut` for per-sample BAMs. Channels updated to be uniform between workflows

ApplyBQSR now also runs per-sample rather than per-interval, made possible because of per-sample output from `nWayOut`

NFTest passes for the actual reads, the header has changed and will require an update of the test expected file to compensate

Should replace #95 minus BaseRecalibrator parallelization, which will be a separate PR

## Testing Results
NFTest produces the same reads, pending update with new file header

Tests for paired mode in progress


# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
