### PR TITLE
Parallelize `BaseRecalibrator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Added
 
 - Options for selecting combination of BQSR and IndelRealignment
+- Resource allocations for validation process
 
 ### Changed
 
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use `resource_handler.handle_resources()`
 - Output per-sample BAMs from IndelRealignment using `--nWayOut`
 - Run `ApplyBQSR` per-sample and per-interval rather than just per-interval
+- Parallelize `BaseRecalibrator` to run per-sample and per-interval
 
 ## [1.0.2] - 2024-10-08
 

--- a/config/resources.json
+++ b/config/resources.json
@@ -12,6 +12,18 @@
                 "max": "1 GB"
             }
         },
+        "run_validate_PipeVal_with_metadata": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.5,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.26,
+                "max": "1 GB"
+            }
+        },
         "extract_GenomeIntervals": {
             "cpus": {
                 "min": 1,
@@ -39,6 +51,18 @@
     },
     "f16": {
         "run_validate_PipeVal": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.06,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.03,
+                "max": "1 GB"
+            }
+        },
+        "run_validate_PipeVal_with_metadata": {
             "cpus": {
                 "min": 1,
                 "fraction": 0.06,
@@ -304,6 +328,18 @@
                 "max": "1 GB"
             }
         },
+        "run_validate_PipeVal_with_metadata": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.03,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.02,
+                "max": "1 GB"
+            }
+        },
         "extract_GenomeIntervals": {
             "cpus": {
                 "min": 1,
@@ -558,6 +594,18 @@
                 "max": "1 GB"
             }
         },
+        "run_validate_PipeVal_with_metadata": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.01,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            }
+        },
         "extract_GenomeIntervals": {
             "cpus": {
                 "min": 1,
@@ -801,6 +849,18 @@
     },
     "m64": {
         "run_validate_PipeVal": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.02,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.00,
+                "max": "1 GB"
+            }
+        },
+        "run_validate_PipeVal_with_metadata": {
             "cpus": {
                 "min": 1,
                 "fraction": 0.02,

--- a/main.nf
+++ b/main.nf
@@ -139,11 +139,6 @@ workflow {
         .set{ input_ch_intervals }
 
 
-    validated_samples_with_index
-        .map{ sample -> sample.id }
-        .flatten()
-        .set{ input_ch_sample_ids }
-
     /**
     *   Indel realignment
     */

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -66,6 +66,7 @@ process run_BaseRecalibrator_GATK {
     interval_padding = params.is_targeted ? "--interval_padding 100" : ""
     combined_interval_options = params.is_targeted ?
         "--intervals \"\$(realpath ${intervals})\" ${interval_padding} --interval-set-rule INTERSECTION" :
+        ""
         "${unmapped_interval_option} --interval-set-rule UNION"
     """
     set -euo pipefail
@@ -272,6 +273,12 @@ workflow recalibrate_base {
 
     run_GatherBQSRReports_GATK.out.gathered_recalibration_table
         .mix(Channel.fromList(recal_tables))
+        .map{ tables ->
+            [
+                tables[0],
+                ['recal_table': tables[1]]
+            ]
+        }
         .set{ ided_recal_tables }
 
     input_samples
@@ -294,7 +301,6 @@ workflow recalibrate_base {
                 joined_input[2].has_unmapped,
                 joined_input[2].id,
                 joined_input[1].recal_table
-
             ]
         }
         .set{ input_ch_apply_bqsr }

--- a/module/base-recalibration.nf
+++ b/module/base-recalibration.nf
@@ -63,10 +63,9 @@ process run_BaseRecalibrator_GATK {
     script:
     base_interval_option = "--intervals ${interval_path}"
     unmapped_interval_option = has_unmapped ? "--intervals unmapped" : ""
-    interval_padding = params.is_targeted ? "--interval_padding 100" : ""
+    interval_padding = params.is_targeted ? "--interval-padding 100" : ""
     combined_interval_options = params.is_targeted ?
         "--intervals \"\$(realpath ${intervals})\" ${interval_padding} --interval-set-rule INTERSECTION" :
-        ""
         "${unmapped_interval_option} --interval-set-rule UNION"
     """
     set -euo pipefail

--- a/module/indel-realignment.nf
+++ b/module/indel-realignment.nf
@@ -67,6 +67,23 @@ process run_RealignerTargetCreator_GATK {
     """
 }
 
+Integer getSortKey(String chr) {
+    String identifier = chr.toUpperCase().replace("CHR", "");
+    if (identifier.isInteger()) {
+        return identifier.toInteger();
+    }
+
+    Map integer_map = [
+        'M': 23,
+        'X': 24,
+        'Y': 25,
+        'NONASSEMBLED': -1
+    ]
+
+    // Return default value of 100 to avoid error
+    return integer_map.getOrDefault(identifier, 100);
+}
+
 /*
     Nextflow module for realigning indels
 
@@ -163,6 +180,23 @@ workflow realign_indels {
         input_ch_rtc
         )
 
+    // Sort intervals to put nonassembled contigs first
+    run_RealignerTargetCreator_GATK.out.ir_targets
+        .map{ ir_target ->
+            [
+                'key': getSortKey(ir_target[2]),
+                'ir_target_data': ir_target
+            ]
+        }
+        .toSortedList{ a, b ->
+            a.key <=> b.key
+        }
+        .flatten()
+        .map{ sorted_data ->
+            sorted_data.ir_target_data
+        }
+        .set{ input_ch_indelrealigner }
+
     run_IndelRealigner_GATK(
         params.reference_fasta,
         params.reference_fasta_fai,
@@ -171,7 +205,7 @@ workflow realign_indels {
         params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz_tbi,
         params.bundle_known_indels_vcf_gz,
         params.bundle_known_indels_vcf_gz_tbi,
-        run_RealignerTargetCreator_GATK.out.ir_targets
+        input_ch_indelrealigner
         )
 
     def basename_map = [:]

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -115,6 +115,10 @@
         "run_validate_PipeVal": {
           "cpus": "1",
           "memory": "1 GB"
+        },
+        "run_validate_PipeVal_with_metadata": {
+          "cpus": "1",
+          "memory": "1 GB"
         }
       },
       "blcds_registered_dataset": false,
@@ -449,6 +453,10 @@
         }
       },
       "withName:run_validate_PipeVal": {
+        "cpus": "1",
+        "memory": "1 GB"
+      },
+      "withName:run_validate_PipeVal_with_metadata": {
         "cpus": "1",
         "memory": "1 GB"
       }

--- a/test/configtest-F32.json
+++ b/test/configtest-F32.json
@@ -115,6 +115,10 @@
         "run_validate_PipeVal": {
           "cpus": "1",
           "memory": "1 GB"
+        },
+        "run_validate_PipeVal_with_metadata": {
+          "cpus": "1",
+          "memory": "1 GB"
         }
       },
       "blcds_registered_dataset": false,
@@ -449,6 +453,10 @@
         }
       },
       "withName:run_validate_PipeVal": {
+        "cpus": "1",
+        "memory": "1 GB"
+      },
+      "withName:run_validate_PipeVal_with_metadata": {
         "cpus": "1",
         "memory": "1 GB"
       }


### PR DESCRIPTION
# Description
<!-- Briefly describe the changes included in this pull request, starting with 'Closes #... if appropriate.  -->

Parallelizing the BaseRecalibrator process

Allow pipeline processes to start in parallel to validation to save runtime

There are marginal differences in the recalibration tables generated (https://sites.google.com/a/broadinstitute.org/legacy-gatk-documentation/methods-and-algorithms/44-Base-Quality-Score-Recalibration-BQSR)

## Testing Results

<!-- If you did not run NFTest, please justify _why_ you feel your changes
     don't need to be tested. -->

- NFTest
  - logs: `<dev-dir>/log-nftest-20250717T030611Z.log`, `<dev-dir>/log-nftest-20250717T203321Z.log`


# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
