### PR TITLE
Sfitz update resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Run `ApplyBQSR` per-sample and per-interval rather than just per-interval
 - Parallelize `BaseRecalibrator` to run per-sample and per-interval
 - Parallelize `PileupSummaries`
+- Resources updated
 
 ## [1.0.2] - 2024-10-08
 

--- a/config/resources.json
+++ b/config/resources.json
@@ -2,7 +2,6 @@
     "f2": {
         "run_validate_PipeVal": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -14,7 +13,6 @@
         },
         "calculate_sha512": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -26,7 +24,6 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -38,7 +35,6 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -50,7 +46,6 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -62,7 +57,6 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -74,7 +68,6 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -86,7 +79,6 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -98,7 +90,6 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -110,7 +101,6 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -122,7 +112,6 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -134,7 +123,6 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -146,7 +134,6 @@
         },
         "run_index_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -158,7 +145,6 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -170,7 +156,6 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -182,7 +167,6 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -194,7 +178,6 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -206,7 +189,6 @@
         },
         "remove_intermediate_files": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -218,7 +200,6 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -230,7 +211,6 @@
         },
         "remove_merged_BAM": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -242,7 +222,6 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -256,7 +235,6 @@
     "f8": {
         "run_validate_PipeVal": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -268,7 +246,6 @@
         },
         "calculate_sha512": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -280,7 +257,6 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -292,7 +268,6 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -304,7 +279,6 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -316,9 +290,8 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.25,
-                "max": 2
+                "max": 1
             },
             "memory": {
                 "min": "2 GB",
@@ -328,31 +301,29 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "6 GB"
+                    "operand": "2 GB"
                 }
             }
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
+                "min": "3 GB",
                 "fraction": 0.25,
-                "max": "4 GB"
+                "max": "3 GB"
             },
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "14 GB"
+                    "operand": "13 GB"
                 }
             }
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -370,7 +341,6 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -388,7 +358,6 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -406,7 +375,6 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.25,
                 "max": 2
             },
@@ -424,7 +392,6 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.25,
                 "max": 2
             },
@@ -442,7 +409,6 @@
         },
         "run_index_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -460,7 +426,6 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -478,7 +443,6 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -496,7 +460,6 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -514,7 +477,6 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -532,7 +494,6 @@
         },
         "remove_intermediate_files": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -544,7 +505,6 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -556,7 +516,6 @@
         },
         "remove_merged_BAM": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -568,7 +527,6 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -588,7 +546,6 @@
     "f16": {
         "run_validate_PipeVal": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -600,7 +557,6 @@
         },
         "calculate_sha512": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -612,7 +568,6 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -624,7 +579,6 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -636,7 +590,6 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -648,7 +601,6 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.062,
                 "max": 1
             },
@@ -660,31 +612,29 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "6 GB"
+                    "operand": "2 GB"
                 }
             }
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.13,
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
+                "min": "3 GB",
                 "fraction": 0.13,
-                "max": "4 GB"
+                "max": "3 GB"
             },
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "14 GB"
+                    "operand": "13 GB"
                 }
             }
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -702,7 +652,6 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -714,13 +663,12 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "7 GB"
+                    "operand": "3 GB"
                 }
             }
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -738,7 +686,6 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.13,
                 "max": 2
             },
@@ -756,7 +703,6 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.13,
                 "max": 2
             },
@@ -774,7 +720,6 @@
         },
         "run_index_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -792,7 +737,6 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -810,7 +754,6 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -828,7 +771,6 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -846,7 +788,6 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -864,7 +805,6 @@
         },
         "remove_intermediate_files": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -876,7 +816,6 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -888,7 +827,6 @@
         },
         "remove_merged_BAM": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -900,7 +838,6 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -920,7 +857,6 @@
     "f32": {
         "run_validate_PipeVal": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -932,7 +868,6 @@
         },
         "calculate_sha512": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -944,7 +879,6 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -956,7 +890,6 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -968,7 +901,6 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -980,7 +912,6 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.13,
                 "max": 1
             },
@@ -992,31 +923,29 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "5 GB"
+                    "operand": "3 GB"
                 }
             }
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.13,
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
+                "min": "3 GB",
                 "fraction": 0.1,
-                "max": "4 GB"
+                "max": "3 GB"
             },
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "14 GB"
+                    "operand": "13 GB"
                 }
             }
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -1034,7 +963,6 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1052,7 +980,6 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1070,7 +997,6 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.06,
                 "max": 2
             },
@@ -1088,7 +1014,6 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.06,
                 "max": 2
             },
@@ -1106,7 +1031,6 @@
         },
         "run_index_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1124,7 +1048,6 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1142,7 +1065,6 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1160,7 +1082,6 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1178,7 +1099,6 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1196,7 +1116,6 @@
         },
         "remove_intermediate_files": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1208,7 +1127,6 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1220,7 +1138,6 @@
         },
         "remove_merged_BAM": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1232,7 +1149,6 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1252,7 +1168,6 @@
     "f72": {
         "run_validate_PipeVal": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1264,7 +1179,6 @@
         },
         "calculate_sha512": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -1276,7 +1190,6 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1288,7 +1201,6 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1300,7 +1212,6 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1312,7 +1223,6 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 4,
                 "fraction": 0.08,
                 "max": 4
             },
@@ -1324,31 +1234,29 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "6 GB"
+                    "operand": "3 GB"
                 }
             }
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.08,
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "3 GB",
                 "fraction": 0.07,
-                "max": "2 GB"
+                "max": "3 GB"
             },
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "8 GB"
+                    "operand": "13 GB"
                 }
             }
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -1366,7 +1274,6 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1384,7 +1291,6 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1402,7 +1308,6 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1420,7 +1325,6 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1438,7 +1342,6 @@
         },
         "run_index_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1456,7 +1359,6 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1474,7 +1376,6 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1492,7 +1393,6 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1510,7 +1410,6 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1528,7 +1427,6 @@
         },
         "remove_intermediate_files": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1540,7 +1438,6 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1552,7 +1449,6 @@
         },
         "remove_merged_BAM": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1564,7 +1460,6 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1584,7 +1479,6 @@
     "m64": {
         "run_validate_PipeVal": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1596,7 +1490,6 @@
         },
         "calculate_sha512": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -1608,7 +1501,6 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1620,7 +1512,6 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1632,7 +1523,6 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1644,7 +1534,6 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 4,
                 "fraction": 0.06,
                 "max": 4
             },
@@ -1656,13 +1545,12 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "30 GB"
+                    "operand": "0 GB"
                 }
             }
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -1680,7 +1568,6 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -1698,7 +1585,6 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1716,7 +1602,6 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1734,7 +1619,6 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1752,7 +1636,6 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
-                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1770,7 +1653,6 @@
         },
         "run_index_SAMtools": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1788,7 +1670,6 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1806,7 +1687,6 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1824,7 +1704,6 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1842,7 +1721,6 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1860,7 +1738,6 @@
         },
         "remove_intermediate_files": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1872,7 +1749,6 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1884,7 +1760,6 @@
         },
         "remove_merged_BAM": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1896,7 +1771,6 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
-                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1934,7 +1808,7 @@
             },
             "memory": {
                 "min": "1 GB",
-                "fraction": 0.03,
+                "fraction": 0.01,
                 "max": "1 GB"
             }
         },
@@ -1995,11 +1869,11 @@
         "run_IndelRealigner_GATK": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.1,
+                "fraction": 0.01,
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "3 GB",
                 "fraction": 0.1,
                 "max": "6 GB"
             },
@@ -2013,7 +1887,7 @@
         "run_GatherBamFiles_Picard": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.25,
+                "fraction": 0.01,
                 "max": 1
             },
             "memory": {

--- a/config/resources.json
+++ b/config/resources.json
@@ -3,7 +3,7 @@
         "run_validate_PipeVal": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.06,
+                "fraction": 0.5,
                 "max": 1
             },
             "memory": {
@@ -15,7 +15,7 @@
         "calculate_sha512": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.06,
+                "fraction": 0.5,
                 "max": 1
             },
             "memory": {
@@ -73,6 +73,18 @@
             }
         },
         "run_IndelRealigner_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.5,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.26,
+                "max": "1 GB"
+            }
+        },
+        "run_GatherBamFiles_Picard": {
             "cpus": {
                 "min": 1,
                 "fraction": 0.5,
@@ -145,6 +157,18 @@
             }
         },
         "run_GetPileupSummaries_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.5,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.26,
+                "max": "1 GB"
+            }
+        },
+        "run_GatherPileupSummaries_GATK": {
             "cpus": {
                 "min": 1,
                 "fraction": 0.5,
@@ -195,7 +219,7 @@
         "remove_interval_BAMs": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.03,
+                "fraction": 0.5,
                 "max": 1
             },
             "memory": {
@@ -227,34 +251,22 @@
                 "fraction": 0.26,
                 "max": "1 GB"
             }
-        },
-        "run_GatherBamFiles_Picard": {
-            "cpus": {
-                "min": 1,
-                "fraction": 0.5,
-                "max": 1
-            },
-            "memory": {
-                "min": "1 GB",
-                "fraction": 0.26,
-                "max": "1 GB"
-            }
-        },
-        "run_GatherPileupSummaries_GATK": {
-            "cpus": {
-                "min": 1,
-                "fraction": 0.5,
-                "max": 1
-            },
-            "memory": {
-                "min": "1 GB",
-                "fraction": 0.26,
-                "max": "1 GB"
-            }
         }
     },
     "f8": {
-        "run_validate_PipeVal_with_metadata": {
+        "run_validate_PipeVal": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.06,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.03,
+                "max": "1 GB"
+            }
+        },
+        "calculate_sha512": {
             "cpus": {
                 "min": 1,
                 "fraction": 0.125,
@@ -266,7 +278,7 @@
                 "max": "1 GB"
             }
         },
-        "calculate_sha512": {
+        "run_validate_PipeVal_with_metadata": {
             "cpus": {
                 "min": 1,
                 "fraction": 0.125,
@@ -304,19 +316,19 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
-                "min": 2,
+                "min": 1,
                 "fraction": 0.25,
                 "max": 2
             },
             "memory": {
-                "min": "4 GB",
+                "min": "2 GB",
                 "fraction": 0.25,
-                "max": "4 GB"
+                "max": "2 GB"
             },
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "4 GB"
+                    "operand": "6 GB"
                 }
             }
         },
@@ -334,7 +346,25 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "12 GB"
+                    "operand": "14 GB"
+                }
+            }
+        },
+        "run_GatherBamFiles_Picard": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.25,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.5,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -365,12 +395,12 @@
             "memory": {
                 "min": "1 GB",
                 "fraction": 0.063,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "2 GB"
+                    "operand": "3 GB"
                 }
             }
         },
@@ -443,6 +473,24 @@
                 "memory": {
                     "strategy": "add",
                     "operand": "3 GB"
+                }
+            }
+        },
+        "run_GatherPileupSummaries_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.125,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.063,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
                 }
             }
         },
@@ -535,42 +583,6 @@
                     "operand": "1 GB"
                 }
             }
-        },
-        "run_GatherBamFiles_Picard": {
-            "cpus": {
-                "min": 1,
-                "fraction": 0.25,
-                "max": 1
-            },
-            "memory": {
-                "min": "2 GB",
-                "fraction": 0.5,
-                "max": "2 GB"
-            },
-            "retry_strategy": {
-                "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
-                }
-            }
-        },
-        "run_GatherPileupSummaries_GATK": {
-            "cpus": {
-                "min": 1,
-                "fraction": 0.125,
-                "max": 1
-            },
-            "memory": {
-                "min": "1 GB",
-                "fraction": 0.063,
-                "max": "1 GB"
-            },
-            "retry_strategy": {
-                "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
-                }
-            }
         }
     },
     "f16": {
@@ -637,18 +649,18 @@
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.0625,
+                "fraction": 0.062,
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
+                "min": "2 GB",
                 "fraction": 0.13,
-                "max": "4 GB"
+                "max": "2 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "6 GB"
                 }
             }
         },
@@ -665,8 +677,26 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "14 GB"
+                }
+            }
+        },
+        "run_GatherBamFiles_Picard": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.25,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.5,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -677,14 +707,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.06,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -695,14 +725,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.07,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -719,26 +749,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
-                }
-            }
-        },
-        "run_GatherBamFiles_Picard": {
-            "cpus": {
-                "min": 1,
-                "fraction": 0.25,
-                "max": 1
-            },
-            "memory": {
-                "min": "2 GB",
-                "fraction": 0.5,
-                "max": "2 GB"
-            },
-            "retry_strategy": {
-                "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -755,8 +767,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -767,14 +779,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.07,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -785,14 +797,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.03,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -803,14 +815,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.07,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -821,14 +833,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.16,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -845,8 +857,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "5 GB"
                 }
             }
         },
@@ -884,6 +896,24 @@
                 "min": "1 GB",
                 "fraction": 0.03,
                 "max": "1 GB"
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.06,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.03,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
             }
         }
     },
@@ -955,14 +985,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
-                "fraction": 0.10,
-                "max": "4 GB"
+                "min": "3 GB",
+                "fraction": 0.1,
+                "max": "3 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "5 GB"
                 }
             }
         },
@@ -974,13 +1004,13 @@
             },
             "memory": {
                 "min": "4 GB",
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": "4 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "14 GB"
                 }
             }
         },
@@ -991,14 +1021,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.5,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1009,14 +1039,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.99,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1027,14 +1057,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.03,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1051,8 +1081,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1069,8 +1099,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1081,14 +1111,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.03,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1099,14 +1129,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.08,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1117,14 +1147,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.03,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1135,14 +1165,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.08,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1159,8 +1189,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "10 GB"
                 }
             }
         },
@@ -1198,6 +1228,24 @@
                 "min": "1 GB",
                 "fraction": 0.02,
                 "max": "1 GB"
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.03,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.02,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
             }
         }
     },
@@ -1275,8 +1323,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "6 GB"
                 }
             }
         },
@@ -1287,14 +1335,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
+                "min": "2 GB",
                 "fraction": 0.07,
-                "max": "4 GB"
+                "max": "2 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1305,14 +1353,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.5,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1323,14 +1371,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.53,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1341,14 +1389,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1365,8 +1413,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1383,8 +1431,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1395,14 +1443,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1413,14 +1461,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.04,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1431,14 +1479,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1449,14 +1497,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.04,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1473,8 +1521,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "10 GB"
                 }
             }
         },
@@ -1513,6 +1561,24 @@
                 "fraction": 0.01,
                 "max": "1 GB"
             }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.01,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
+            }
         }
     },
     "m64": {
@@ -1524,7 +1590,7 @@
             },
             "memory": {
                 "min": "1 GB",
-                "fraction": 0.00,
+                "fraction": 0.01,
                 "max": "1 GB"
             }
         },
@@ -1548,7 +1614,7 @@
             },
             "memory": {
                 "min": "1 GB",
-                "fraction": 0.00,
+                "fraction": 0.01,
                 "max": "1 GB"
             }
         },
@@ -1560,7 +1626,7 @@
             },
             "memory": {
                 "min": "1 GB",
-                "fraction": 0.00,
+                "fraction": 0.01,
                 "max": "1 GB"
             }
         },
@@ -1572,7 +1638,7 @@
             },
             "memory": {
                 "min": "1 GB",
-                "fraction": 0.00,
+                "fraction": 0.01,
                 "max": "1 GB"
             }
         },
@@ -1589,8 +1655,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "30 GB"
                 }
             }
         },
@@ -1607,8 +1673,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "15 GB"
                 }
             }
         },
@@ -1619,14 +1685,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.5,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1637,14 +1703,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.51,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1655,14 +1721,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
-                "fraction": 0.00,
-                "max": "2 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1679,8 +1745,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1697,8 +1763,8 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1709,14 +1775,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
-                "fraction": 0.00,
-                "max": "2 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1727,14 +1793,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1745,14 +1811,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
-                "fraction": 0.00,
-                "max": "2 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1763,14 +1829,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "5 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "5 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "9 GB"
                 }
             }
         },
@@ -1787,8 +1853,62 @@
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "10 GB"
+                }
+            }
+        },
+        "remove_intermediate_files": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.02,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            }
+        },
+        "remove_interval_BAMs": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.02,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            }
+        },
+        "remove_merged_BAM": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.02,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.02,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
                 }
             }
         }
@@ -1809,12 +1929,24 @@
         "calculate_sha512": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.06,
+                "fraction": 0.01,
                 "max": 1
             },
             "memory": {
                 "min": "1 GB",
                 "fraction": 0.03,
+                "max": "1 GB"
+            }
+        },
+        "run_validate_PipeVal_with_metadata": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.01,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
                 "max": "1 GB"
             }
         },
@@ -1845,36 +1977,36 @@
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
                 "min": 2,
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": 6
             },
             "memory": {
                 "min": "4 GB",
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": "10 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "10 GB"
                 }
             }
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
                 "min": 1,
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": 1
             },
             "memory": {
-                "min": "4 GB",
-                "fraction": 0.10,
-                "max": "5 GB"
+                "min": "2 GB",
+                "fraction": 0.1,
+                "max": "6 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "14 GB"
                 }
             }
         },
@@ -1885,14 +2017,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
-                "fraction": 0.5,
-                "max": "2 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1903,14 +2035,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
-                "fraction": 0.53,
-                "max": "10 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "19 GB"
                 }
             }
         },
@@ -1921,14 +2053,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 4
+                    "strategy": "add",
+                    "operand": "7 GB"
                 }
             }
         },
@@ -1940,13 +2072,13 @@
             },
             "memory": {
                 "min": "4 GB",
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": "8 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1958,13 +2090,13 @@
             },
             "memory": {
                 "min": "4 GB",
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": "8 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "8 GB"
                 }
             }
         },
@@ -1975,14 +2107,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -1993,14 +2125,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "3 GB",
-                "fraction": 0.05,
-                "max": "10 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "19 GB"
                 }
             }
         },
@@ -2011,14 +2143,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
+                "min": "1 GB",
                 "fraction": 0.01,
-                "max": "2 GB"
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "3 GB"
                 }
             }
         },
@@ -2029,14 +2161,14 @@
                 "max": 1
             },
             "memory": {
-                "min": "3 GB",
-                "fraction": 0.05,
-                "max": "10 GB"
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "19 GB"
                 }
             }
         },
@@ -2048,13 +2180,13 @@
             },
             "memory": {
                 "min": "4 GB",
-                "fraction": 0.10,
+                "fraction": 0.1,
                 "max": "10 GB"
             },
             "retry_strategy": {
                 "memory": {
-                    "strategy": "exponential",
-                    "operand": 2
+                    "strategy": "add",
+                    "operand": "10 GB"
                 }
             }
         },
@@ -2092,6 +2224,24 @@
                 "min": "1 GB",
                 "fraction": 0.01,
                 "max": "1 GB"
+            }
+        },
+        "run_GatherBQSRReports_GATK": {
+            "cpus": {
+                "min": 1,
+                "fraction": 0.01,
+                "max": 1
+            },
+            "memory": {
+                "min": "1 GB",
+                "fraction": 0.01,
+                "max": "1 GB"
+            },
+            "retry_strategy": {
+                "memory": {
+                    "strategy": "add",
+                    "operand": "1 GB"
+                }
             }
         }
     }

--- a/config/resources.json
+++ b/config/resources.json
@@ -346,7 +346,7 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "13 GB"
+                    "operand": "6 GB"
                 }
             }
         },
@@ -678,7 +678,7 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "13 GB"
+                    "operand": "6 GB"
                 }
             }
         },
@@ -1010,7 +1010,7 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "13 GB"
+                    "operand": "6 GB"
                 }
             }
         },
@@ -1342,7 +1342,7 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "13 GB"
+                    "operand": "6 GB"
                 }
             }
         },
@@ -2006,7 +2006,7 @@
             "retry_strategy": {
                 "memory": {
                     "strategy": "add",
-                    "operand": "14 GB"
+                    "operand": "6 GB"
                 }
             }
         },

--- a/config/resources.json
+++ b/config/resources.json
@@ -2,6 +2,7 @@
     "f2": {
         "run_validate_PipeVal": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -13,6 +14,7 @@
         },
         "calculate_sha512": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -24,6 +26,7 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -35,6 +38,7 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -46,6 +50,7 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -57,6 +62,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -68,6 +74,7 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -79,6 +86,7 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -90,6 +98,7 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -101,6 +110,7 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -112,6 +122,7 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -123,6 +134,7 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -134,6 +146,7 @@
         },
         "run_index_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -145,6 +158,7 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -156,6 +170,7 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -167,6 +182,7 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -178,6 +194,7 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -189,6 +206,7 @@
         },
         "remove_intermediate_files": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -200,6 +218,7 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -211,6 +230,7 @@
         },
         "remove_merged_BAM": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -222,6 +242,7 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.5,
                 "max": 1
             },
@@ -235,6 +256,7 @@
     "f8": {
         "run_validate_PipeVal": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -246,6 +268,7 @@
         },
         "calculate_sha512": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -257,6 +280,7 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -268,6 +292,7 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -279,6 +304,7 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -290,6 +316,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -307,6 +334,7 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -324,6 +352,7 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -341,6 +370,7 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -358,6 +388,7 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -375,6 +406,7 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.25,
                 "max": 2
             },
@@ -392,6 +424,7 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.25,
                 "max": 2
             },
@@ -409,6 +442,7 @@
         },
         "run_index_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -426,6 +460,7 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -443,6 +478,7 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -460,6 +496,7 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -477,6 +514,7 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -494,6 +532,7 @@
         },
         "remove_intermediate_files": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -505,6 +544,7 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -516,6 +556,7 @@
         },
         "remove_merged_BAM": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -527,6 +568,7 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.125,
                 "max": 1
             },
@@ -546,6 +588,7 @@
     "f16": {
         "run_validate_PipeVal": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -557,6 +600,7 @@
         },
         "calculate_sha512": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -568,6 +612,7 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -579,6 +624,7 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -590,6 +636,7 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -601,6 +648,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.062,
                 "max": 1
             },
@@ -618,6 +666,7 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.13,
                 "max": 1
             },
@@ -635,6 +684,7 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -652,6 +702,7 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -669,6 +720,7 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -686,6 +738,7 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.13,
                 "max": 2
             },
@@ -703,6 +756,7 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.13,
                 "max": 2
             },
@@ -720,6 +774,7 @@
         },
         "run_index_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -737,6 +792,7 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -754,6 +810,7 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -771,6 +828,7 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -788,6 +846,7 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -805,6 +864,7 @@
         },
         "remove_intermediate_files": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -816,6 +876,7 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -827,6 +888,7 @@
         },
         "remove_merged_BAM": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -838,6 +900,7 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -857,6 +920,7 @@
     "f32": {
         "run_validate_PipeVal": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -868,6 +932,7 @@
         },
         "calculate_sha512": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -879,6 +944,7 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -890,6 +956,7 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -901,6 +968,7 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -912,6 +980,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.13,
                 "max": 1
             },
@@ -929,6 +998,7 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.13,
                 "max": 1
             },
@@ -946,6 +1016,7 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -963,6 +1034,7 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -980,6 +1052,7 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -997,6 +1070,7 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.06,
                 "max": 2
             },
@@ -1014,6 +1088,7 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.06,
                 "max": 2
             },
@@ -1031,6 +1106,7 @@
         },
         "run_index_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1048,6 +1124,7 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1065,6 +1142,7 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1082,6 +1160,7 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1099,6 +1178,7 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1116,6 +1196,7 @@
         },
         "remove_intermediate_files": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1127,6 +1208,7 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1138,6 +1220,7 @@
         },
         "remove_merged_BAM": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1149,6 +1232,7 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.03,
                 "max": 1
             },
@@ -1168,6 +1252,7 @@
     "f72": {
         "run_validate_PipeVal": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1179,6 +1264,7 @@
         },
         "calculate_sha512": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -1190,6 +1276,7 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1201,6 +1288,7 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1212,6 +1300,7 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1223,6 +1312,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
+                "min": 4,
                 "fraction": 0.08,
                 "max": 4
             },
@@ -1240,6 +1330,7 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.08,
                 "max": 1
             },
@@ -1257,6 +1348,7 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -1274,6 +1366,7 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1291,6 +1384,7 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1308,6 +1402,7 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1325,6 +1420,7 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1342,6 +1438,7 @@
         },
         "run_index_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1359,6 +1456,7 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1376,6 +1474,7 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1393,6 +1492,7 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1410,6 +1510,7 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1427,6 +1528,7 @@
         },
         "remove_intermediate_files": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1438,6 +1540,7 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1449,6 +1552,7 @@
         },
         "remove_merged_BAM": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1460,6 +1564,7 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.01,
                 "max": 1
             },
@@ -1479,6 +1584,7 @@
     "m64": {
         "run_validate_PipeVal": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1490,6 +1596,7 @@
         },
         "calculate_sha512": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -1501,6 +1608,7 @@
         },
         "run_validate_PipeVal_with_metadata": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1512,6 +1620,7 @@
         },
         "extract_GenomeIntervals": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1523,6 +1632,7 @@
         },
         "run_SplitIntervals_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1534,6 +1644,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
             "cpus": {
+                "min": 4,
                 "fraction": 0.06,
                 "max": 4
             },
@@ -1551,6 +1662,7 @@
         },
         "run_IndelRealigner_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.06,
                 "max": 1
             },
@@ -1568,6 +1680,7 @@
         },
         "run_GatherBamFiles_Picard": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.25,
                 "max": 1
             },
@@ -1585,6 +1698,7 @@
         },
         "run_BaseRecalibrator_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1602,6 +1716,7 @@
         },
         "run_ApplyBQSR_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1619,6 +1734,7 @@
         },
         "run_MergeSamFiles_Picard": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1636,6 +1752,7 @@
         },
         "deduplicate_records_SAMtools": {
             "cpus": {
+                "min": 2,
                 "fraction": 0.03,
                 "max": 2
             },
@@ -1653,6 +1770,7 @@
         },
         "run_index_SAMtools": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1670,6 +1788,7 @@
         },
         "run_GetPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1687,6 +1806,7 @@
         },
         "run_GatherPileupSummaries_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1704,6 +1824,7 @@
         },
         "run_CalculateContamination_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1721,6 +1842,7 @@
         },
         "run_DepthOfCoverage_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1738,6 +1860,7 @@
         },
         "remove_intermediate_files": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1749,6 +1872,7 @@
         },
         "remove_interval_BAMs": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1760,6 +1884,7 @@
         },
         "remove_merged_BAM": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },
@@ -1771,6 +1896,7 @@
         },
         "run_GatherBQSRReports_GATK": {
             "cpus": {
+                "min": 1,
                 "fraction": 0.02,
                 "max": 1
             },

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -78,35 +78,39 @@
         },
         "run_ApplyBQSR_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_BaseRecalibrator_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_CalculateContamination_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_DepthOfCoverage_GATK": {
           "cpus": "1",
           "memory": "14 GB"
         },
+        "run_GatherBQSRReports_GATK": {
+          "cpus": "1",
+          "memory": "1 GB"
+        },
         "run_GatherBamFiles_Picard": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_GatherPileupSummaries_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_GetPileupSummaries_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_IndelRealigner_GATK": {
           "cpus": "1",
-          "memory": "4 GB"
+          "memory": "3 GB"
         },
         "run_MergeSamFiles_Picard": {
           "cpus": "2",
@@ -114,7 +118,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
           "cpus": "1",
-          "memory": "4 GB"
+          "memory": "2 GB"
         },
         "run_SplitIntervals_GATK": {
           "cpus": "1",
@@ -122,7 +126,7 @@
         },
         "run_index_SAMtools": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_validate_PipeVal": {
           "cpus": "1",
@@ -192,74 +196,80 @@
       "retry_information": {
         "deduplicate_records_SAMtools": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "8 GB",
+            "strategy": "add"
           }
         },
         "run_ApplyBQSR_GATK": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "7 GB",
+            "strategy": "add"
           }
         },
         "run_BaseRecalibrator_GATK": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         },
         "run_CalculateContamination_GATK": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "7 GB",
+            "strategy": "add"
           }
         },
         "run_DepthOfCoverage_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "5 GB",
+            "strategy": "add"
+          }
+        },
+        "run_GatherBQSRReports_GATK": {
+          "memory": {
+            "operand": "1 GB",
+            "strategy": "add"
           }
         },
         "run_GatherBamFiles_Picard": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "7 GB",
+            "strategy": "add"
           }
         },
         "run_GatherPileupSummaries_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         },
         "run_GetPileupSummaries_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         },
         "run_IndelRealigner_GATK": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "6 GB",
+            "strategy": "add"
           }
         },
         "run_MergeSamFiles_Picard": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "8 GB",
+            "strategy": "add"
           }
         },
         "run_RealignerTargetCreator_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "2 GB",
+            "strategy": "add"
           }
         },
         "run_index_SAMtools": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         }
       },
@@ -376,7 +386,7 @@
           "1": "27.9 GB",
           "2": "31 GB",
           "3": "31 GB",
-          "closure": "retry_updater(27.9 GB, exponential, 2, $task.attempt, memory)"
+          "closure": "retry_updater(27.9 GB, add, 8 GB, $task.attempt, memory)"
         }
       },
       "withName:extract_GenomeIntervals": {
@@ -398,73 +408,82 @@
       "withName:run_ApplyBQSR_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "8 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(2 GB, exponential, 4, $task.attempt, memory)"
+          "3": "15 GB",
+          "closure": "retry_updater(1 GB, add, 7 GB, $task.attempt, memory)"
         }
       },
       "withName:run_BaseRecalibrator_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
-          "2": "8 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(2 GB, exponential, 4, $task.attempt, memory)"
+          "1": "1 GB",
+          "2": "4 GB",
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_CalculateContamination_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "8 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(2 GB, exponential, 4, $task.attempt, memory)"
+          "3": "15 GB",
+          "closure": "retry_updater(1 GB, add, 7 GB, $task.attempt, memory)"
         }
       },
       "withName:run_DepthOfCoverage_GATK": {
         "cpus": "1",
         "memory": {
           "1": "14 GB",
-          "2": "27.9 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(14 GB, exponential, 2, $task.attempt, memory)"
+          "2": "19 GB",
+          "3": "24 GB",
+          "closure": "retry_updater(14 GB, add, 5 GB, $task.attempt, memory)"
+        }
+      },
+      "withName:run_GatherBQSRReports_GATK": {
+        "cpus": "1",
+        "memory": {
+          "1": "1 GB",
+          "2": "2 GB",
+          "3": "3 GB",
+          "closure": "retry_updater(1 GB, add, 1 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GatherBamFiles_Picard": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "8 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(2 GB, exponential, 4, $task.attempt, memory)"
+          "3": "15 GB",
+          "closure": "retry_updater(1 GB, add, 7 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GatherPileupSummaries_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "4 GB",
-          "3": "8 GB",
-          "closure": "retry_updater(2 GB, exponential, 2, $task.attempt, memory)"
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GetPileupSummaries_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "4 GB",
-          "3": "8 GB",
-          "closure": "retry_updater(2 GB, exponential, 2, $task.attempt, memory)"
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_IndelRealigner_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "4 GB",
-          "2": "16 GB",
-          "3": "31 GB",
-          "closure": "retry_updater(4 GB, exponential, 4, $task.attempt, memory)"
+          "1": "3 GB",
+          "2": "9 GB",
+          "3": "15 GB",
+          "closure": "retry_updater(3 GB, add, 6 GB, $task.attempt, memory)"
         }
       },
       "withName:run_MergeSamFiles_Picard": {
@@ -473,16 +492,16 @@
           "1": "27.9 GB",
           "2": "31 GB",
           "3": "31 GB",
-          "closure": "retry_updater(27.9 GB, exponential, 2, $task.attempt, memory)"
+          "closure": "retry_updater(27.9 GB, add, 8 GB, $task.attempt, memory)"
         }
       },
       "withName:run_RealignerTargetCreator_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "4 GB",
-          "2": "8 GB",
-          "3": "16 GB",
-          "closure": "retry_updater(4 GB, exponential, 2, $task.attempt, memory)"
+          "1": "2 GB",
+          "2": "4 GB",
+          "3": "6 GB",
+          "closure": "retry_updater(2 GB, add, 2 GB, $task.attempt, memory)"
         }
       },
       "withName:run_SplitIntervals_GATK": {
@@ -492,10 +511,10 @@
       "withName:run_index_SAMtools": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "4 GB",
-          "3": "8 GB",
-          "closure": "retry_updater(2 GB, exponential, 2, $task.attempt, memory)"
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_validate_PipeVal": {

--- a/test/configtest-F32.json
+++ b/test/configtest-F32.json
@@ -78,35 +78,39 @@
         },
         "run_ApplyBQSR_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_BaseRecalibrator_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_CalculateContamination_GATK": {
           "cpus": "1",
-          "memory": "5 GB"
+          "memory": "1 GB"
         },
         "run_DepthOfCoverage_GATK": {
           "cpus": "1",
           "memory": "28.8 GB"
         },
+        "run_GatherBQSRReports_GATK": {
+          "cpus": "1",
+          "memory": "1 GB"
+        },
         "run_GatherBamFiles_Picard": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_GatherPileupSummaries_GATK": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_GetPileupSummaries_GATK": {
           "cpus": "1",
-          "memory": "5 GB"
+          "memory": "1 GB"
         },
         "run_IndelRealigner_GATK": {
           "cpus": "1",
-          "memory": "4 GB"
+          "memory": "3 GB"
         },
         "run_MergeSamFiles_Picard": {
           "cpus": "2",
@@ -114,7 +118,7 @@
         },
         "run_RealignerTargetCreator_GATK": {
           "cpus": "1",
-          "memory": "4 GB"
+          "memory": "3 GB"
         },
         "run_SplitIntervals_GATK": {
           "cpus": "1",
@@ -122,7 +126,7 @@
         },
         "run_index_SAMtools": {
           "cpus": "1",
-          "memory": "2 GB"
+          "memory": "1 GB"
         },
         "run_validate_PipeVal": {
           "cpus": "1",
@@ -192,74 +196,80 @@
       "retry_information": {
         "deduplicate_records_SAMtools": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "8 GB",
+            "strategy": "add"
           }
         },
         "run_ApplyBQSR_GATK": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "7 GB",
+            "strategy": "add"
           }
         },
         "run_BaseRecalibrator_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         },
         "run_CalculateContamination_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "9 GB",
+            "strategy": "add"
           }
         },
         "run_DepthOfCoverage_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "10 GB",
+            "strategy": "add"
+          }
+        },
+        "run_GatherBQSRReports_GATK": {
+          "memory": {
+            "operand": "1 GB",
+            "strategy": "add"
           }
         },
         "run_GatherBamFiles_Picard": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "7 GB",
+            "strategy": "add"
           }
         },
         "run_GatherPileupSummaries_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         },
         "run_GetPileupSummaries_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "9 GB",
+            "strategy": "add"
           }
         },
         "run_IndelRealigner_GATK": {
           "memory": {
-            "operand": "4",
-            "strategy": "exponential"
+            "operand": "6 GB",
+            "strategy": "add"
           }
         },
         "run_MergeSamFiles_Picard": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "8 GB",
+            "strategy": "add"
           }
         },
         "run_RealignerTargetCreator_GATK": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         },
         "run_index_SAMtools": {
           "memory": {
-            "operand": "2",
-            "strategy": "exponential"
+            "operand": "3 GB",
+            "strategy": "add"
           }
         }
       },
@@ -376,7 +386,7 @@
           "1": "57.6 GB",
           "2": "64 GB",
           "3": "64 GB",
-          "closure": "retry_updater(57.6 GB, exponential, 2, $task.attempt, memory)"
+          "closure": "retry_updater(57.6 GB, add, 8 GB, $task.attempt, memory)"
         }
       },
       "withName:extract_GenomeIntervals": {
@@ -398,73 +408,82 @@
       "withName:run_ApplyBQSR_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "8 GB",
-          "3": "32 GB",
-          "closure": "retry_updater(2 GB, exponential, 4, $task.attempt, memory)"
+          "3": "15 GB",
+          "closure": "retry_updater(1 GB, add, 7 GB, $task.attempt, memory)"
         }
       },
       "withName:run_BaseRecalibrator_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "4 GB",
-          "3": "8 GB",
-          "closure": "retry_updater(2 GB, exponential, 2, $task.attempt, memory)"
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_CalculateContamination_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "5 GB",
+          "1": "1 GB",
           "2": "10 GB",
-          "3": "20 GB",
-          "closure": "retry_updater(5 GB, exponential, 2, $task.attempt, memory)"
+          "3": "19 GB",
+          "closure": "retry_updater(1 GB, add, 9 GB, $task.attempt, memory)"
         }
       },
       "withName:run_DepthOfCoverage_GATK": {
         "cpus": "1",
         "memory": {
           "1": "28.8 GB",
-          "2": "57.6 GB",
-          "3": "64 GB",
-          "closure": "retry_updater(28.8 GB, exponential, 2, $task.attempt, memory)"
+          "2": "38.8 GB",
+          "3": "48.8 GB",
+          "closure": "retry_updater(28.8 GB, add, 10 GB, $task.attempt, memory)"
+        }
+      },
+      "withName:run_GatherBQSRReports_GATK": {
+        "cpus": "1",
+        "memory": {
+          "1": "1 GB",
+          "2": "2 GB",
+          "3": "3 GB",
+          "closure": "retry_updater(1 GB, add, 1 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GatherBamFiles_Picard": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "8 GB",
-          "3": "32 GB",
-          "closure": "retry_updater(2 GB, exponential, 4, $task.attempt, memory)"
+          "3": "15 GB",
+          "closure": "retry_updater(1 GB, add, 7 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GatherPileupSummaries_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "4 GB",
-          "3": "8 GB",
-          "closure": "retry_updater(2 GB, exponential, 2, $task.attempt, memory)"
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_GetPileupSummaries_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "5 GB",
+          "1": "1 GB",
           "2": "10 GB",
-          "3": "20 GB",
-          "closure": "retry_updater(5 GB, exponential, 2, $task.attempt, memory)"
+          "3": "19 GB",
+          "closure": "retry_updater(1 GB, add, 9 GB, $task.attempt, memory)"
         }
       },
       "withName:run_IndelRealigner_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "4 GB",
-          "2": "16 GB",
-          "3": "64 GB",
-          "closure": "retry_updater(4 GB, exponential, 4, $task.attempt, memory)"
+          "1": "3 GB",
+          "2": "9 GB",
+          "3": "15 GB",
+          "closure": "retry_updater(3 GB, add, 6 GB, $task.attempt, memory)"
         }
       },
       "withName:run_MergeSamFiles_Picard": {
@@ -473,16 +492,16 @@
           "1": "57.6 GB",
           "2": "64 GB",
           "3": "64 GB",
-          "closure": "retry_updater(57.6 GB, exponential, 2, $task.attempt, memory)"
+          "closure": "retry_updater(57.6 GB, add, 8 GB, $task.attempt, memory)"
         }
       },
       "withName:run_RealignerTargetCreator_GATK": {
         "cpus": "1",
         "memory": {
-          "1": "4 GB",
-          "2": "8 GB",
-          "3": "16 GB",
-          "closure": "retry_updater(4 GB, exponential, 2, $task.attempt, memory)"
+          "1": "3 GB",
+          "2": "6 GB",
+          "3": "9 GB",
+          "closure": "retry_updater(3 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_SplitIntervals_GATK": {
@@ -492,10 +511,10 @@
       "withName:run_index_SAMtools": {
         "cpus": "1",
         "memory": {
-          "1": "2 GB",
+          "1": "1 GB",
           "2": "4 GB",
-          "3": "8 GB",
-          "closure": "retry_updater(2 GB, exponential, 2, $task.attempt, memory)"
+          "3": "7 GB",
+          "closure": "retry_updater(1 GB, add, 3 GB, $task.attempt, memory)"
         }
       },
       "withName:run_validate_PipeVal": {


### PR DESCRIPTION
# Description
Update resources based on PCAWG runs or in some cases all runs listed in the runlogger.   Details of what changed are shown in these figures, with changed values boxed in red.

**New resources:**
<img width="1356" height="475" alt="image" src="https://github.com/user-attachments/assets/3d9f9de9-fbea-46a2-861b-da137b56855c" />

**Previous resources** (current main branch):
<img width="1343" height="486" alt="image" src="https://github.com/user-attachments/assets/a05116bc-fb29-4c53-a884-153ba0bf1b19" />

Note, all retries have been changed to `add`, and the value given in the chart is the final sum of original and add.


##### Initial `F72` test run, sample `DO11441`
  - `run_IndelRealigner_GATK` memory = `2 GB`
  - 3 out of 26 scatters initially failed, succeeded on retry. 
  - `Duration    : 7h 53m 18s`
  - `CPU hours   : 104.6 (2% failed)`
  - log: `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/sfitz-update-resources/DO11441-noBQSR-default/recalibrate-BAM-1.0.2/DO11441/log-recalibrate-BAM-1.0.2-20250814T222529Z`

##### Second `F72` test run, sample `DO11441`
 - `run_IndelRealigner_GATK` memory = `4 GB`
 - No fails
 - `Duration    : 8h 36m 6s`
 - `CPU hours   : 107.9`

Having a few fail and go to retry while allowing twice as many to run at one time may be the best strategy, even if all or most intervals fail on first try in some larger samples.  To compromise, I set it at `3G` with retry adding `6G`.  For all runs in the runlogger, no run had `peak_rss` > `5 GB`

# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
